### PR TITLE
Added content per request of team talent and add'l contributors 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,9 @@ collections:
   positions:
     permalink: /positions/:title/
     output: true
+  interviews:
+    permalink: /interviews/:title/
+    output: true
 
 # Style Variables
 brand_color: "#1188ff"

--- a/_config.yml
+++ b/_config.yml
@@ -26,19 +26,25 @@ navigation:
 - text: Introduction
   url: index.html
   internal: true
-- text: The Interview Process
-  url: interview-process/
+- text: Who we are hiring
+  url: who-we-are-hiring/
   internal: true
-- text: Government Pay Grades Explained
-  url: pay-grades/
+- text: How to apply
+  url: how-to-apply/
+  internal: true
+- text: Interview process
+  url: interview-process/
   internal: true
 - text: Benefits
   url: benefits/
   internal: true
-- text: Leave Policies
+- text: Government pay grades explained
+  url: pay-grades/
+  internal: true
+- text: Leave policies
   url: leave-policies/
   internal: true
-- text: Conferences, Trainings, and Travel
+- text: Conferences, trainings, and travel
   url: conferences-training-travel/
   internal: true
 
@@ -46,6 +52,12 @@ repos:
 - name: Guides Template
   description: Main repository
   url: https://github.com/18F/joining-18f
+
+# Collections
+collections:
+  positions:
+    permalink: /positions/:title/
+    output: true
 
 # Style Variables
 brand_color: "#1188ff"

--- a/_interviews/engineering-team.md
+++ b/_interviews/engineering-team.md
@@ -1,0 +1,24 @@
+---
+title: Engineering Team
+layout: default
+permalink: /interview-process/interviews/engineering-team/
+---
+
+If you are a software developer and applying to work on our Engineering team, you will have two interviews: a technical interview, and a core values interview. Although each interview is different, we generally follow the format described below. Sometimes we find one aspect of a candidate's work particularly fascinating, and we'll want to spend more time talking about it. Or we might be having a really nice discussion on architecture and we don't want it to end. You should come prepared to discuss previous software you've built, why you architected it the way that you did, and what you learned from it.
+
+#### Technical interview format
+- An introduction  (~ 5 min)
+- Technical questions about the candidate’s previous work and experience that can be answered and discussed without coding on a whiteboard (NO brainteasers)  (~20 min)
+- Code reviewing a piece of  preselected code  (~15-20 min) 
+- Some time devoted to a highly coached “think out loud” code writing or system diagramming session. This could include writing or discussing a short function or adding a small feature to an existing piece of code (~30-40 min)
+- Time for the candidate to ask questions of us (~15 min)
+
+#### Core values interview format 
+
+This interview can be a little more of a freeform discussion, but it should drive at the qualifications described in the Core Values section below. 
+
+ - Intros (~5 min)
+ - Why this candidate wants to work at 18F, previous civic oriented service (~15 min)
+ - Discussion of past work in teams, including the processes, locations (remote vs on site) and how they would like to work in the future (~15 min)
+ - Discussion of previous work or thoughts and feelings about open source software, agile/iterative development, developing for the user (~25 min)
+ - Discussion of how the candidate has handled previous conflict, past failures and successes, and where they see opportunities for growth (~20 min)

--- a/_interviews/product-team.md
+++ b/_interviews/product-team.md
@@ -1,0 +1,16 @@
+---
+title: Product Team
+layout: default
+permalink: /interview-process/interviews/product-team/
+---
+
+There isn't one description that matches the role of all Product Leads at 18F. Ultimately, it depends on the nature of the relationship between 18F and a partner agency.  Some relationships have one account manager with multiple product managers who focus on building out separate products while others have one person who is an Account Manager/Product Manager hybrid. No matter where you fall on the spectrum between Account Manager, Product Manager (and both!), you'll have three interviews:
+
+### Core Values Interview (1 hour)
+We want to know about what you're passionate about, how you worked with teams in the past and why you think 18F is a good fit for you. We expect you to ask the same of us. 
+
+### Problem Solving Interview (1 hour)
+We'll present you with hypothetical problems and actual problems that we've faced to see how you would handle them. We’re also very curious about your response to problems that you’ve faced in your experience.
+
+### Technical Interview (1 hour)
+This is where we dive deep into the process, methodologies and tools that you use to get the job done and your beliefs on how teams should work together.

--- a/_positions/agile-coach.md
+++ b/_positions/agile-coach.md
@@ -1,7 +1,7 @@
 ---
 title: Agile Coach
 layout: default
-permalink: who-we-are-hiring/positons/agile-coach/
+permalink: who-we-are-hiring/positions/agile-coach/
 ---
 Experience transforming initiatives to deliver lasting change within
 agencies that focus on delivering value for citizens. Coaches may be

--- a/_positions/agile-coach.md
+++ b/_positions/agile-coach.md
@@ -1,0 +1,59 @@
+---
+title: Agile Coach
+layout: default
+permalink: who-we-are-hiring/positons/agile-coach/
+---
+Experience transforming initiatives to deliver lasting change within
+agencies that focus on delivering value for citizens. Coaches may be
+required to work either:
+
+-   at the team level, working with teams to ensure that delivery teams
+within agencies are adopting agile and performing effectively
+
+-   at the portfolio or program level, to help agencies to establish the
+right processes for managing a portfolio of work in an agile way
+
+-   at the organization level, to drive strategic change across the
+    organization and ensure that adoption of agile techniques is
+    embedded from the most senior levels of the organization
+
+-   or across all levels to ensure that organizations adopt a pragmatic
+    approach to the way in which they govern delivery and continuous
+    improvement of digital services
+
+Primarily responsible for:
+
+-   Embed an agile culture using techniques from a wide range or agile
+    and lean methodologies and frameworks, but be methodology agnostic
+
+-   Help to create an open and trust-based environment, which enables a
+    focus on delivery and facilitates continuous improvement
+
+-   Assess the culture of a team or organization and delivery processes
+    in place to identify improvements and facilitate these
+    improvements with the right type of support
+
+-   Showcase relevant tools and techniques such as coaching, advising,
+    workshops, and mentoring
+
+-   Engage with stakeholders at all levels of the organization
+
+-   Develop clear lines of escalation, in agreement with senior managers
+
+-   Ensure any stakeholder can easily find out an accurate and current
+    project or program status, without disruption to delivery
+
+-   Work effectively with other suppliers and agencies
+
+-   Apply best tools and techniques to: team roles, behaviors, structure
+    and culture, agile ceremonies and practices, knowledge transfer
+    and sharing, program management, cross-team coordination, and
+    overall governance of digital service delivery
+
+-   Ensure key metrics and requirements that support the team and
+    delivery are well defined and maintained
+
+-   Equip staff with the ability to coach others
+
+-   If organization level, executive coaching on the fundamental
+    considerations of digital service delivery design

--- a/_positions/back-end-web-developer.md
+++ b/_positions/back-end-web-developer.md
@@ -1,0 +1,39 @@
+---
+title: Backend Web Developer
+layout: default
+permalink: who-we-are-hiring/positions/back-end-developer/
+---
+
+Experience using modern, open source software to prototype and deploy
+backend web applications, including all aspects of server-side
+processing, data storage, and integration with frontend development.
+
+Primarily responsible for:
+
+-   Web development using open-source web programming languages (e.g.,
+Ruby, Python) and frameworks (e.g., Django, Rails)
+
+-   Developing and consuming web-based, RESTful APIs
+
+-   Using and working in team environments that use agile methodologies
+(e.g., Scrum, Lean)
+
+-   Authoring developer-friendly documentation (e.g., API documentation,
+deployment operations)
+
+-   Test-driven development
+
+-   Use of version control systems, specifically Git and GitHub
+
+-   Quickly researching and learning new programming tools and
+techniques
+
+-   Relational and non-relational database systems
+
+-   Scalable search technology (e.g. ElasticSearch, Solr)
+
+-   Handling large data sets and scaling their handling and storage
+
+-   Using and working with open source solutions and community
+
+-   Communicating technical concepts to a non-technical audience

--- a/_positions/business-analyst.md
+++ b/_positions/business-analyst.md
@@ -1,0 +1,37 @@
+---
+title: Business Analyst
+layout: default
+permalink: who-we-are-hiring/positions/business-analyst/
+---
+
+Familiar with a range of digital/web services and solutions, ideally
+where open source and cloud technologies and agile development
+methodologies have been applied. An eye for detail, excellent
+communication skills, ability to rationalize complex information to make
+it understandable for others to work, and ability to interrogate
+reported information and challenge sources where inconsistencies are
+found.
+
+Primarily responsible for:
+
+-   Support agencies by analyzing propositions and assessing
+decision-making factors such as strategic alignment, cost/benefit,
+and risk
+
+-   Work closely with the Product Manager to define a product approach
+to meet the specified user need
+
+-   Define skill requirements and map internal, agency, and external
+(partners/specialist contractors) resources
+
+-   Work with the owning agency to ensure they have the budget to cover
+the proposed approach and resource requirements during delivery
+and analyze what provision they have for on going running costs
+
+-   Analyze and map the risks of this product approach and propose
+mitigation solutions
+
+-   Define how the predicted user and financial benefit can be realized,
+and how channel shift will be measured
+
+-   Make a recommendation for action against the analysis done

--- a/_positions/delivery-manager.md
+++ b/_positions/delivery-manager.md
@@ -1,7 +1,7 @@
 ---
 title: Delivery Manager
 layout: default
-permalink: who-we-are-hiring/positons/delivery-manager/
+permalink: who-we-are-hiring/positions/delivery-manager/
 ---
 
 Experience setting up teams for successful delivery by removing

--- a/_positions/delivery-manager.md
+++ b/_positions/delivery-manager.md
@@ -1,0 +1,38 @@
+---
+title: Delivery Manager
+layout: default
+permalink: who-we-are-hiring/positons/delivery-manager/
+---
+
+Experience setting up teams for successful delivery by removing
+obstacles (or blockers to progress), constantly helping the team to
+become more self-organizing, and enabling the work the team does rather
+than impose how it’s done.
+
+Manages one or more agile projects, typically to deliver a specific
+product or transformation via a multi-disciplinary, high-skilled digital
+team. Adept at delivering complex digital projects, breaking down
+barriers to the team, and both planning at a higher level and getting
+into the detail to make things happen when needed.
+
+Defines project needs and feeds these into the portfolio/program process
+to enable resources to be appropriately allocated.
+
+Primarily responsible for:
+
+-   Delivering projects and products using the appropriate agile project
+management methodology, learning & iterating frequently
+
+-   Working with the Product Manager to define the roadmap for any given
+product and translating this into user stories
+
+-   Leading the collaborative, dynamic planning process -- prioritizing
+the work that needs to be done against the capacity and capability
+of the team
+
+-   Matrix-managing a multi-disciplinary team
+
+-   Ensuring all products are built to an appropriate level of quality
+for the stage (alpha/beta/production)
+
+-   Actively and openly sharing knowledge of best practices

--- a/_positions/devops-engineer.md
+++ b/_positions/devops-engineer.md
@@ -1,7 +1,7 @@
 ---
 title: DevOps Engineer
 layout: default
-permalink: who-we-are-hiring/positons/devops-engineer/
+permalink: who-we-are-hiring/positions/devops-engineer/
 ---
 
 Experience serving as the engineer of complex technology implementations

--- a/_positions/devops-engineer.md
+++ b/_positions/devops-engineer.md
@@ -1,0 +1,33 @@
+---
+title: DevOps Engineer
+layout: default
+permalink: who-we-are-hiring/positons/devops-engineer/
+---
+
+Experience serving as the engineer of complex technology implementations
+in a product-centric environment. Comfortable with bridging the gap
+between legacy development or operations teams and working toward a
+shared culture and vision. Works tirelessly to arm developers with the
+best tools and ensuring system uptime and performance.
+
+Primarily responsible for:
+
+-   Deploying and configuring services using infrastructure as a service
+providers (e.g., Amazon Web Services, Microsoft Azure, Google
+Compute Engine, RackSpace/OpenStack)
+
+-   Configuring and managing Linux-based servers to serve a dynamic
+website
+
+-   Debugging cluster-based computing architectures
+
+-   Using scripting or basic programming skills to solve problems
+
+-   Installation and management of open source monitoring tools
+
+-   Configuration management tools (e.g., Puppet, Chef, Ansible, Salt)
+
+-   Architecture for continuous integration and deployment, and
+continuous monitoring
+
+-   Containerization technologies (e.g., LXC, Docker, Rocket)

--- a/_positions/digital-performance-analyst.md
+++ b/_positions/digital-performance-analyst.md
@@ -1,0 +1,36 @@
+---
+title: Digital Performance Analyst
+layout: default
+permalink: who-we-are-hiring/positons/digital-performance-analyst/
+---
+
+Experience specifying, collecting, and presenting key performance data
+and analysis for a given digital service. Supports Product Managers by
+generating new and useful information and translating it into actions
+that will allow them to iteratively improve their service for users.
+Possesses analytical and problem-solving skills necessary for quickly
+developing recommendations based on the quantitative and qualitative
+evidence gathered via web analytics, financial data, and user feedback.
+Confident in explaining technical concepts to senior officials with
+limited technological background. And comfortable working with data,
+from gathering and analysis through to design and presentation.
+
+Primarily responsible for:
+
+-   Support the Product Manager to make sure their service meets
+performance requirements
+
+-   Communicate service performance against key indicators to internal
+and external stakeholders
+
+-   Ensure high-quality analysis of agency transaction data
+
+-   Support the procurement of the necessary digital platforms to
+support automated and real-time collection and presentation of
+data
+
+-   Share examples of best practice in digital performance management
+across government
+
+-   Identify delivery obstacles to improving transactional performance
+in agencies and working with teams to overcome those obstacles

--- a/_positions/digital-performance-analyst.md
+++ b/_positions/digital-performance-analyst.md
@@ -1,7 +1,7 @@
 ---
 title: Digital Performance Analyst
 layout: default
-permalink: who-we-are-hiring/positons/digital-performance-analyst/
+permalink: who-we-are-hiring/positions/digital-performance-analyst/
 ---
 
 Experience specifying, collecting, and presenting key performance data

--- a/_positions/front-end-web-developer.md
+++ b/_positions/front-end-web-developer.md
@@ -1,0 +1,40 @@
+---
+title: Frontend Web Developer
+layout: default
+permalink: who-we-are-hiring/positons/frontend-web-developer/
+---
+
+Experience using modern, frontend web development tools, techniques, and
+methods for the creation and deployment of user-facing interfaces. Is
+comfortable working in an agile and lean environment to routinely deploy
+changes.
+
+Primarily responsible for:
+
+-   Frontend web development using modern techniques and frameworks
+(e.g., HTML5, CSS3, CSS frameworks like LESS and SASS, Responsive
+Design, Bourbon, Twitter Bootstrap)
+
+-   JavaScript development using modern standards, including strict mode
+compliance, modularization techniques and tools, and frameworks
+and libraries (e.g., jQuery, MV\* frameworks such as Backbone.js
+and Ember.js, D3)
+
+-   Consuming RESTful APIs
+
+-   Using and working in team environments that use agile methodologies
+(e.g., Scrum, Lean)
+
+-   Use of version control systems, specifically Git and GitHub
+
+-   Ensuring Section 508 Compliance
+
+-   Quickly researching and learning new programming tools and
+techniques
+
+-   Using and working with open source solutions and community
+
+-   Creating web layouts from static images
+
+-   Creating views and templates in full-stack frameworks like Rails,
+Express, or Django

--- a/_positions/front-end-web-developer.md
+++ b/_positions/front-end-web-developer.md
@@ -1,7 +1,7 @@
 ---
 title: Frontend Web Developer
 layout: default
-permalink: who-we-are-hiring/positons/frontend-web-developer/
+permalink: who-we-are-hiring/positions/frontend-web-developer/
 ---
 
 Experience using modern, frontend web development tools, techniques, and

--- a/_positions/interaction-designer.md
+++ b/_positions/interaction-designer.md
@@ -1,7 +1,7 @@
 ---
 title: Interaction Designer / User Researcher / Usability Tester
 layout: default
-permalink: who-we-are-hiring/positons/interaction-design/
+permalink: who-we-are-hiring/positions/interaction-design/
 ---
 
 The Interaction Designer / User Researcher / Usability Tester is part of

--- a/_positions/interaction-designer.md
+++ b/_positions/interaction-designer.md
@@ -1,0 +1,59 @@
+---
+title: Interaction Designer / User Researcher / Usability Tester
+layout: default
+permalink: who-we-are-hiring/positons/interaction-design/
+---
+
+The Interaction Designer / User Researcher / Usability Tester is part of
+a highly collaborative, multi-disciplinary team focused on improving
+usability, user experience, and driving user adoption and engagement.
+They are responsible for conducting user research, analysis & synthesis,
+persona development, interaction design, and usability testing to create
+products that delight our customers.
+
+Primarily responsible for:
+
+-   Conduct stakeholder interviews, user requirements analysis, task
+analysis, conceptual modeling, information architecture,
+interaction design, and usability testing
+
+-   Design and specify user interfaces and information architecture
+
+-   Lead participatory and iterative design activities, including
+observational studies, customer interviews, usability testing, and
+other forms of requirements discovery
+
+-   Produce user requirements specifications & experience goals,
+personas, storyboards, scenarios, flowcharts, design prototypes,
+and design specifications
+
+-   Effectively communicate research findings, conceptual ideas,
+detailed design, and design rationale and goals both verbally and
+visually
+
+-   Plan and facilitate collaborative critiques and analysis & synthesis
+working sessions
+
+-   Work closely with visual designers and development teams to ensure
+that customer goals are met and design specifications are
+delivered upon
+
+-   Designs and develops primarily internet/web pages and applications
+
+-   Develops proof-of-concepts and prototypes of easy-to-navigate user
+interfaces (UIs) that consists of web pages with graphics, icons,
+and color schemes that are visually appealing
+
+-   Researches user needs as well as potential system enhancements
+
+-   Has familiarity to, or may actually: code, test, debug documents,
+and implement web applications using a variety of platforms
+
+-   Planning, recruiting, and facilitating the usability testing of a
+system
+
+-   Analyzing and synthesizing the results of usability testing in order
+to provide recommendations for change to a system
+
+-   May create such artifacts as Usability Testing Plan, Testing
+Scripts, and Usability Testing Report

--- a/_positions/product-manager.md
+++ b/_positions/product-manager.md
@@ -1,0 +1,36 @@
+---
+title: Product Manager
+layout: default
+permalink: who-we-are-hiring/positions/product-manager/
+---
+
+Experience managing the delivery, ongoing success, and continuous
+improvement of one or more digital products and/or platforms.
+
+Primarily responsible for:
+
+-   Lead one or more multi-disciplinary agile delivery teams to deliver
+excellent new products and/or iterations to existing products to
+meet user needs
+
+-   Gather user requirements based on a communicable understanding of
+diverse audience groups
+
+-   Define and get stakeholder buy-in for product definition and
+delivery approach
+
+-   Create effective, prioritized product descriptions, and delivery
+plans to meet user needs in a cost-effective way
+
+-   Interpret user research in order to make the correct product
+decisions, noting that users do not always know what they want
+
+-   Continually keep abreast of changes to user habits, preferences, and
+behaviors across various digital platforms and their implications
+for successful delivery of government digital services
+
+-   Underpin the delivery and iteration of digital services through
+effective analysis of qualitative and quantitative user data
+
+-   Communicate credibly with a wide range of digital delivery
+disciplines and talent

--- a/_positions/security-engineer.md
+++ b/_positions/security-engineer.md
@@ -1,0 +1,23 @@
+---
+title: Security Engineer
+layout: default
+permalink: who-we-are-hiring/positions/security-engineer/
+---
+
+Experience serving as the security engineer of complex technology
+implementations in a product-centric environment. Comfortable with
+bridging the gap between legacy development or operations teams and
+working toward a shared culture and vision. Works tirelessly to ensure
+help developers create the most secure systems in the world while
+enhancing the privacy of all system users. Experience with white-hat
+hacking and fundamental computer science concepts strongly desired.
+
+Primarily responsible for:
+
+-   Performing security audits, risk analysis, application-level
+vulnerability testing, and security code reviews
+
+-   Develop and implement technical solutions to help mitigate security
+vulnerabilities
+
+-   Conduct research to identify new attack vectors

--- a/_positions/technical-architect.md
+++ b/_positions/technical-architect.md
@@ -1,0 +1,49 @@
+---
+title: Technical Architect
+layout: default
+permalink: who-we-are-hiring/positions/technical-architect/
+---
+
+Experience serving as the manager of complex technology implementations,
+with an eye toward constant reengineering and refactoring to ensure the
+simplest and most elegant system possible to accomplish the desired
+need.
+
+Understands how to maximally leverage the open source community to
+deploy systems on infrastructure as a service providers. Comfortable
+with liberally sharing knowledge across a multi-disciplinary team and
+working within agile methodologies. A full partner in the determination
+of vision, objectives, and success criteria.
+
+Primarily responsible for:
+
+-   Architecting the overall system, by using prototyping and proof of
+concepts, which may include:
+
+    -   modern programming languages (e.g., Ruby, Python, Node.js) and
+    web frameworks (e.g., Django, Rails)
+
+    -   modern front-end web programming techniques (e.g., HTML5, CSS3,
+    RESTful APIs) and frameworks (e.g., Twitter Bootstrap, jQuery)
+
+    -   relational databases (e.g., PostgreSQL), and “NoSQL” databases
+    (e.g., Cassandra, MongoDB)
+
+    -   automated configuration management (e.g., Chef, Puppet, Ansible,
+    Salt), continuous integration/deployment, and continuous
+    monitoring solutions
+
+-   Use of version control systems, specifically Git and GitHub
+
+-   Ensuring strategic alignment of technical design and architecture to
+meet business growth and direction, and stay on top of emerging
+technologies
+
+-   Decomposing business and system architecture to support
+clean-interface multi-team development
+
+-   Developing product roadmaps, backlogs, and measurable success
+criteria, and writing user stories (i.e., can establish a path to
+delivery for breaking down stories)
+
+-   Clearly communicates and works with stakeholders at every level

--- a/_positions/visual-designer.md
+++ b/_positions/visual-designer.md
@@ -1,0 +1,39 @@
+---
+title: Visual Designer
+layout: default
+permalink: who-we-are-hiring/positions/visual-designer/
+---
+
+The Visual Designer starts with a deep understanding of the goals of
+customers and the business so that they can create experiences that
+delight. Visual Designers will be well-versed in all aspects of current
+visual design standards and trends and will be responsible for managing
+project design reviews, resource planning, and execution for all project
+work related to visual design.
+
+Primarily responsible for:
+
+-   Oversees all visual design efforts
+
+-   Guides, mentors, and coaches team members while leading projects to
+successful completion
+
+-   Develops and maintains relationships with key peers in Marketing,
+Branding, UX leaders, IT leaders, and others to identify and plan
+creative solutions
+
+-   Manages external service resources and budgets for visual design
+
+-   Ensures successful completion of all work executed by the team (on
+time, on budget, and ensuring quality)
+
+-   Ensures compliance with the project management methodologies and the
+Project Management Office processes and standards
+
+-   Develops, maintains, and ensures compliance of application release
+management, outage management and change control processes and
+standards
+
+-   Defines, creates, communicates, and manages resource plans and other
+required project documentation such as style guides and provides
+updates as necessary

--- a/_positions/writer-content-designer-strategist.md
+++ b/_positions/writer-content-designer-strategist.md
@@ -1,0 +1,46 @@
+---
+title: Writer / Content Designer / Content Strategist
+layout: default
+permalink: who-we-are-hiring/positions/content-designer/
+---
+
+Experience developing the strategy and execution of content across
+digital channels.
+
+Primarily responsible for:
+
+-   Improves content creation efforts by helping to lead the research &
+development of interactive and experiential storytelling for
+projects
+
+-   Advise how to improve the ongoing iteration of content models
+
+-   Collaborate with designers and other content strategists to improve
+how the effectiveness of digital, print, and other content is
+measured
+
+-   Develop and maintain appropriate voice for produced content
+
+-   Advise how to streamline content production and management solutions
+and processes, based on user research
+
+-   Assign, edit, and produce content for products, services, and
+various projects
+
+-   Plan and facilitate content strategy workshops and brainstorming
+sessions on developing content and content services (including API
+development)
+
+-   Collaborate closely with developers and designers to create, test,
+and deploy effective content marketing experiences using the Agile
+method of software development
+
+-   Offer educated recommendations on how to deliver a consistent,
+sustainable and standards-driven execution of content strategy
+across products, services, and projects
+
+-   Collaborate with content managers, writers, information architects,
+interaction designers, developers, and content creators of all
+types
+
+-   Participate, as needed, on an Agile software development scrum teams

--- a/index.md
+++ b/index.md
@@ -19,14 +19,4 @@ We will accomplish our mission by:
 * deploying tools and services early and often
 
 
-## Who Are We Hiring?
 
-We are looking for candidates who are passionate about our mission, with top-notch software development, design, content, and operations skills to match. Please see [this blog post](https://18f.gsa.gov/2015/02/25/We-Are-Hiring/) for a more detailed description of our positions.
-    
-## Where Are We Hiring?
-
-Everywhere in the United States! If you have no experience working on remote teams, or are applying for a role that requires in-person interactions with clients, we will ask that you work out of either our San Francisco or D.C. office. However, the majority of our team is distributed across the country, in places like Chicago, New York, Raleigh, Tuscon, Austin, Dayton, Philadelphia, Santa Barbara, Seattle, and Portland.
-
-## How Do I Apply?
-
-Please send your resume or CV to join18F@gsa.gov. We’ll forward it to the appropriate people. And there’s no need for a cover letter — an informal email will do. Within three weeks, our team will review your application information and contact you about next steps.

--- a/pages/benefits.md
+++ b/pages/benefits.md
@@ -25,11 +25,5 @@ Government's version of a 401K offers up to 5 percent matching: [Thrift Savings 
 
 Telework provides flexibility for an employee. It improves the morale and productivity of staff by allowing for greater collaboration amongst peers. 18F recognizes these benefits and encourages working from home with the approval of their administrative supervisor or his/her designee. This policy adheres to and is in conjunction with [GSA's Mobility and Telework Policy](http://www.gsa.gov/graphics/staffoffices/GSAteleworkpolicy.pdf).
 
-### Commuter Benefits
-
-
-### Discounts
-
-GSA has partnerships with many companies to provide discounts including gym memberships, car rentals, and hotel accomodations. 
 
 

--- a/pages/benefits.md
+++ b/pages/benefits.md
@@ -16,3 +16,20 @@ There is also [Life Insurance](http://www.opm.gov/healthcare-insurance/life-insu
 
 Government's version of a 401K : [Thrift Savings Plan](https://www.tsp.gov/)
 
+### Retirement
+
+Government's version of a 401K offers up to 5 percent matching: [Thrift Savings Plan](https://www.tsp.gov/)
+
+
+### Teleworking
+
+Telework provides flexibility for an employee. It improves the morale and productivity of staff by allowing for greater collaboration amongst peers. 18F recognizes these benefits and encourages working from home with the approval of their administrative supervisor or his/her designee. This policy adheres to and is in conjunction with [GSA's Mobility and Telework Policy](http://www.gsa.gov/graphics/staffoffices/GSAteleworkpolicy.pdf).
+
+### Commuter Benefits
+
+
+### Discounts
+
+GSA has partnerships with many companies to provide discounts including gym memberships, car rentals, and hotel accomodations. 
+
+

--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -1,0 +1,11 @@
+---
+permalink: /how-to-apply/
+layout: default
+title: How to apply
+---
+
+Submit your application through [U.S. Digital Services](https://www.whitehouse.gov/digital/united-states-digital-service/apply). Enter "join18F" as the referral code. There's no need for a cover letter; within three weeks our team will review your application and contact you about next steps. Check out more information about our interview process [here](/joining-18f/interview-process).
+
+### Tips on resume preparation
+
+

--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -5,7 +5,3 @@ title: How to apply
 ---
 
 Submit your application through [U.S. Digital Services](https://www.whitehouse.gov/digital/united-states-digital-service/apply). Enter "join18F" as the referral code. There's no need for a cover letter; within three weeks our team will review your application and contact you about next steps. Check out more information about our interview process [here](/joining-18f/interview-process).
-
-### Tips on resume preparation
-
-

--- a/pages/interview-process.md
+++ b/pages/interview-process.md
@@ -4,9 +4,11 @@ layout: default
 title: The 18F Interview Process
 ---
 
-### First Steps
+### Phone screen
 
-If you'd like to apply to 18F, the first thing you should do is write us an email (<a href="mailto:join18f@gsa.gov">join18f@gsa.gov</a>) introducing yourself, with your resume attached. Within three weeks, our team will review your resume and if it seems like you might be a fit for 18F, we'll reach out to schedule a 30-minute phone call. On the phone call, plan to talk more about your skills and experience, what you're passionate about, and the work we do here at 18F. 
+After you submit your application through [U.S. Digital Services](https://www.whitehouse.gov/digital/united-states-digital-service/apply) within three weeks, our team will review your resume. If it seems like you are a good fit for 18F, we will reach out to schedule a 30-minute phone call. On the phone call, plan to talk more about your skills and experience, what you're passionate about, and the work we do here at 18F. 
+
+
 
 ### In-Person (or Videochat) Interviews
 
@@ -16,40 +18,18 @@ After your phone chat, the 18F-er you chatted with will submit their notes to ou
 
 If you're new to working for the federal government, it's important to know that all government positions require some kind of background check. Most positions at 18F require a public trust position clearance, which is more thorough than most private sector background checks, but not as intensive as a higher security clearance. The clearance process adds some time and forms to the hiring process, but GSA's human resources team will be there to guide you. 
 
-#### Interviewing for the Engineering Team
+### Basic rubric and criteria
 
-If you're a software developer and applying to work on our Engineering team, you will have two interviews: a technical interview, and a core values interview. Although each interview is different, we generally follow the format described below. Sometimes we find one aspect of a candidate's work particularly fascinating, and we'll want to spend more time talking about it. Or we might be having a really nice discussion on architecture and we don't want it to end. You should come prepared to discuss previous software you've built, why you designed it the way that you did, and what you learned from it.
+After your interview, the interviewer(s) will evaluate along the basic rubric below. Interviewers evaluate candidates without discussing the candidate with their interview partner or other team members. After a written evaluation, all interviewers will meet and discuss the candidate. 
 
-##### Technical Interview Format
-
- - Introduction (~ 5 min)
- - Technical questions about the candidate’s previous work and experience that can be answered and discussed without coding on a whiteboard (NO brainteasers) (~20 min)
- - Code reviewing a piece of preselected code (~15-20 min) 
- - Some time devoted to a highly coached “think out loud” code writing or system diagramming session. This could include writing or discussing a short function or adding a small feature to an existing piece of code (~30-40 min)
- - Time for the candidate to ask questions of us (~15 min)
-
-##### Core Values Interview Format 
-
-This interview can be a little more of a freeform discussion, but it should drive at the qualifications described in the Core Values section below. 
-
- - Introduction (~5 min)
- - Why this candidate wants to work at 18F, previous civic oriented service (~15 min)
- - Discussion of past work in teams, including the processes, locations (remote vs on site) and how they would like to work in the future (~15 min)
- - Discussion of previous work or thoughts and feelings about open source software, Agile/iterative development, developing for the user (~25 min)
- - Discussion of how the candidate has handled previous conflict, past failures and successes, and where they see opportunities for growth (~20 min)
-
-##### Basic Rubric and Criteria
-
-After your interview, the interviewer(s) will evaluate you along the basic rubric below. Interviewers evaluate candidates without discussing the candidate with their interview partner or other team members. After a written evaluation, all interviewers will meet and discuss the candidate. 
-
-*Principles Alignment*
+##### Principles alignment
 
  - Strong desire to serve
  - Embraces motivations of open source 
  - Embraces user feedback as a way of driving a project 
- - Understands working iteratively or as an Agile team 
+ - Understands working iteratively or as agile team 
 
-*Technical Competence*
+##### Technical competence
 
  - Knowledge of programming language(s) 
  - Knowledge of web framework(s) or other relevant frameworks
@@ -57,24 +37,61 @@ After your interview, the interviewer(s) will evaluate you along the basic rubri
  - Understanding of web technology 
  - Understanding of modularity
 
-*Communication and Collaboration Skills*
+##### Communication and collaboration skills
 
  - Ability to articulate technical concepts 
  - Ability to speak concisely and boldly
+ - Understands working iteratively or as agile team
  - Teachability
  - Quick learning
  - Flexibility of thought
 
-*Leadership and Entrepreneurship*
+##### Leadership and entrepreneurship
 
  - Capable of evangelism
  - Can they teach us something we don’t know?
  - Will they “raise the bar” of our team?
 
-*Creativity*
+##### Creativity
 
  - Ability to translate creativity into practical solutions 
  - Change hearts and minds
 
-#### Interviewing for Design, Team Operations, Content, and Product
+### Interviewing for the engineering team
 
+If you are a software developer and applying to work on our Engineering team, you will have two interviews: a technical interview, and a core values interview. Although each interview is different, we generally follow the format described below. Sometimes we find one aspect of a candidate's work particularly fascinating, and we'll want to spend more time talking about it. Or we might be having a really nice discussion on architecture and we don't want it to end. You should come prepared to discuss previous software you've built, why you architected it the way that you did, and what you learned from it.
+
+##### Technical interview format
+
+ - An introduction  (~ 5 min)
+ - Technical questions about the candidate’s previous work and experience that can be answered and discussed without coding on a whiteboard (NO brainteasers)  (~20 min)
+ - Code reviewing a piece of  preselected code  (~15-20 min) 
+ - Some time devoted to a highly coached “think out loud” code writing or system diagramming session. This could include writing or discussing a short function or adding a small feature to an existing piece of code (~30-40 min)
+ - Time for the candidate to ask questions of us (~15 min)
+
+##### Core values interview format 
+
+This interview can be a little more of a freeform discussion, but it should drive at the qualifications described in the Core Values section below. 
+
+ - Intros (~5 min)
+ - Why this candidate wants to work at 18F, previous civic oriented service (~15 min)
+ - Discussion of past work in teams, including the processes, locations (remote vs on site) and how they would like to work in the future (~15 min)
+ - Discussion of previous work or thoughts and feelings about open source software, agile/iterative development, developing for the user (~25 min)
+ - Discussion of how the candidate has handled previous conflict, past failures and successes, and where they see opportunities for growth (~20 min)
+
+### Interviewing for a Product Lead position
+
+There isn't one description that matches the role of all Product Leads at 18F. Ultimately, it depends on the nature of the relationship between 18F and a partner agency.  Some relationships have one account manager with multiple product managers who focus on building out separate products while others have one person who is an Account Manager/Product Manager hybrid. No matter where you fall on the spectrum between Account Manager, Product Manager (and both!), you'll have three interviews:
+
+##### Core Values Interview (1 hour)
+We want to know about what you're passionate about, how you worked with teams in the past and why you think 18F is a good fit for you. We expect you to ask the same of us. 
+
+##### Problem Solving Interview (1 hour)
+We'll present you with hypothetical problems and actual problems that we've faced to see how you would handle them. We’re also very curious about your response to problems that you’ve faced in your experience.
+
+##### Technical Interview (1 hour)
+This is where we dive deep into the process, methodologies and tools that you use to get the job done and your beliefs on how teams should work together.  
+
+#### Interviewing for design, team operations, and content
+
+- Coming soon

--- a/pages/interview-process.md
+++ b/pages/interview-process.md
@@ -6,7 +6,7 @@ title: The 18F Interview Process
 
 ### Phone screen
 
-After you submit your application through [U.S. Digital Services](https://www.whitehouse.gov/digital/united-states-digital-service/apply) within three weeks, our team will review your resume. If it seems like you are a good fit for 18F, we will reach out to schedule a 30-minute phone call. On the phone call, plan to talk more about your skills and experience, what you're passionate about, and the work we do here at 18F. 
+After you submit your application through [U.S. Digital Services](https://www.whitehouse.gov/digital/united-states-digital-service/apply), within three weeks our team will review your resume. If it seems like you are a good fit for 18F, we will reach out to schedule a 30-minute phone call. On the phone call, plan to talk more about your skills and experience, what you're passionate about, and the work we do here at 18F. 
 
 
 
@@ -22,76 +22,49 @@ If you're new to working for the federal government, it's important to know that
 
 After your interview, the interviewer(s) will evaluate along the basic rubric below. Interviewers evaluate candidates without discussing the candidate with their interview partner or other team members. After a written evaluation, all interviewers will meet and discuss the candidate. 
 
-##### Principles alignment
+- Principles alignment
 
- - Strong desire to serve
- - Embraces motivations of open source 
- - Embraces user feedback as a way of driving a project 
- - Understands working iteratively or as agile team 
+	 - Strong desire to serve
+	 - Embraces motivations of open source 
+	 - Embraces user feedback as a way of driving a project 
+	 - Understands working iteratively or as agile team 	
 
-##### Technical competence
+- Technical competence
 
- - Knowledge of programming language(s) 
- - Knowledge of web framework(s) or other relevant frameworks
- - Demonstrated ability to write well-structured code
- - Understanding of web technology 
- - Understanding of modularity
+	 - Knowledge of programming language(s) 
+	 - Knowledge of web framework(s) or other relevant frameworks
+	 - Demonstrated ability to write well-structured code
+	 - Understanding of web technology 
+	 - Understanding of modularity
 
-##### Communication and collaboration skills
+-  Communication and collaboration skills
 
- - Ability to articulate technical concepts 
- - Ability to speak concisely and boldly
- - Understands working iteratively or as agile team
- - Teachability
- - Quick learning
- - Flexibility of thought
+	 - Ability to articulate technical concepts 
+	 - Ability to speak concisely and boldly
+	 - Understands working iteratively or as agile team
+	 - Teachability
+	 - Quick learning
+	 - Flexibility of thought
 
-##### Leadership and entrepreneurship
+- Leadership and entrepreneurship
 
- - Capable of evangelism
- - Can they teach us something we don’t know?
- - Will they “raise the bar” of our team?
+	 - Capable of evangelism
+	 - Can they teach us something we don’t know?
+	 - Will they “raise the bar” of our team?
 
-##### Creativity
+-  Creativity
 
- - Ability to translate creativity into practical solutions 
- - Change hearts and minds
+	 - Ability to translate creativity into practical solutions 
+	 - Change hearts and minds
 
-### Interviewing for the engineering team
+### Interviewing for a specific team? 
 
-If you are a software developer and applying to work on our Engineering team, you will have two interviews: a technical interview, and a core values interview. Although each interview is different, we generally follow the format described below. Sometimes we find one aspect of a candidate's work particularly fascinating, and we'll want to spend more time talking about it. Or we might be having a really nice discussion on architecture and we don't want it to end. You should come prepared to discuss previous software you've built, why you architected it the way that you did, and what you learned from it.
+Check out more interviewing information for each of our teams. 
 
-##### Technical interview format
+<ul>
+	{% for interview in site.interviews %}
+		<li><a href="{{site.baseurl}}{{ interview.url }}">{{ interview.title }}</a></li>
+	{% endfor %}
+</ul>
 
- - An introduction  (~ 5 min)
- - Technical questions about the candidate’s previous work and experience that can be answered and discussed without coding on a whiteboard (NO brainteasers)  (~20 min)
- - Code reviewing a piece of  preselected code  (~15-20 min) 
- - Some time devoted to a highly coached “think out loud” code writing or system diagramming session. This could include writing or discussing a short function or adding a small feature to an existing piece of code (~30-40 min)
- - Time for the candidate to ask questions of us (~15 min)
-
-##### Core values interview format 
-
-This interview can be a little more of a freeform discussion, but it should drive at the qualifications described in the Core Values section below. 
-
- - Intros (~5 min)
- - Why this candidate wants to work at 18F, previous civic oriented service (~15 min)
- - Discussion of past work in teams, including the processes, locations (remote vs on site) and how they would like to work in the future (~15 min)
- - Discussion of previous work or thoughts and feelings about open source software, agile/iterative development, developing for the user (~25 min)
- - Discussion of how the candidate has handled previous conflict, past failures and successes, and where they see opportunities for growth (~20 min)
-
-### Interviewing for a Product Lead position
-
-There isn't one description that matches the role of all Product Leads at 18F. Ultimately, it depends on the nature of the relationship between 18F and a partner agency.  Some relationships have one account manager with multiple product managers who focus on building out separate products while others have one person who is an Account Manager/Product Manager hybrid. No matter where you fall on the spectrum between Account Manager, Product Manager (and both!), you'll have three interviews:
-
-##### Core Values Interview (1 hour)
-We want to know about what you're passionate about, how you worked with teams in the past and why you think 18F is a good fit for you. We expect you to ask the same of us. 
-
-##### Problem Solving Interview (1 hour)
-We'll present you with hypothetical problems and actual problems that we've faced to see how you would handle them. We’re also very curious about your response to problems that you’ve faced in your experience.
-
-##### Technical Interview (1 hour)
-This is where we dive deep into the process, methodologies and tools that you use to get the job done and your beliefs on how teams should work together.  
-
-#### Interviewing for design, team operations, and content
-
-- Coming soon
+Don't see the team you are interviewing with? Design, content, and operations information will be added soon. 	

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -1,5 +1,5 @@
 ---
-title: Who we are hiring
+title: Who we are hiring?
 layout: default
 permalink: /who-we-are-hiring/
 ---
@@ -7,9 +7,11 @@ permalink: /who-we-are-hiring/
 
 We are looking for candidates who are passionate about our mission, with top-notch software development, design, content, and operations skills to match.
 
-## Where Are We Hiring?
+## Where are we hiring?
 
 Everywhere in the United States! If you have no experience working on remote teams, or are applying for a role that requires in-person interactions with clients, we will ask that you work out of either our San Francisco or D.C. office. However, the majority of our team is distributed across the country, in places like Chicago, New York, Raleigh, Tuscon, Austin, Dayton, Philadelphia, Santa Barbara, Seattle, and Portland.
+
+## What roles we are hiring?
 
 Our rapidly growing team is home to a variety of roles, including these:
 

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -1,0 +1,21 @@
+---
+title: Who we are hiring
+layout: default
+permalink: /who-we-are-hiring/
+---
+
+
+We are looking for candidates who are passionate about our mission, with top-notch software development, design, content, and operations skills to match.
+
+## Where Are We Hiring?
+
+Everywhere in the United States! If you have no experience working on remote teams, or are applying for a role that requires in-person interactions with clients, we will ask that you work out of either our San Francisco or D.C. office. However, the majority of our team is distributed across the country, in places like Chicago, New York, Raleigh, Tuscon, Austin, Dayton, Philadelphia, Santa Barbara, Seattle, and Portland.
+
+Our rapidly growing team is home to a variety of roles, including these:
+
+
+<ul>
+{% for position in site.positions %}
+	<li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
Still a WIP but added:  
- navigation tabs to follow the process of applying to 18F: Intro, Who we are hiring, How to apply, Interview process.
- Updated the "How to apply" section to go to USDS application. 
- positions that are included in the Agile BPA descriptions as per request from @jamiealbrecht 
- Adjusted the interview section. Basic criteria is mid level and edited specific interview details for engineering and product to follow at the bottom. 
