### PR TITLE
Put jobs into teams

### DIFF
--- a/_positions/18F-consulting.md
+++ b/_positions/18F-consulting.md
@@ -2,13 +2,12 @@
 title: 18F Consulting
 layout: default
 permalink: who-we-are-hiring/positions/18f-consulting/
+team: consulting
 ---
 # Management and organization structure
 
 As a member of [18F Consulting](https://18f.gsa.gov/consulting/),
-you’ll ultimately report to the Director of 18F Consulting. 18F
-Consulting is part of [18F](https://18f.gsa.gov/) at the [General
-Services Administration](http://www.gsa.gov/).
+you’ll ultimately report to the Director of 18F Consulting. 
 
 18F Consulting supports the mission and organizational priorities of 18F
 by working on select, high-profile, high-impact projects.
@@ -79,11 +78,11 @@ makes sense.
 
 While we “default to open,” during design and development, the
 environment is often tightly locked down to minimize security risk to
-the agency. However, most design and development is posted to Github
+the agency. However, most design and development is posted to GitHub
 repositories during development, and is later opened up to the world
 after launch. (Depending on the project, it may be posted publicly
 during development.) Openness extends to open data. We use open data
-when it is available, and design with the goal of opening up data after
+when it;s available, and design with the goal of opening up data after
 launch.
 
 We also collaborate with the public. Many of our deliverables must be
@@ -91,11 +90,11 @@ made available for long periods of public review and comment. They’ll be
 listed in the Federal Register, and if the piece is politically
 interesting, it may generate hundreds or thousands of comments.
 
-<span id="h.gjdgxs" class="anchor"></span>18F Consulting team members
+18F Consulting team members
 tend to be self-directed. We constantly monitor the priorities and work
 on what’s most important at any given moment. We use how many Americans
 (or future Americans) are directly affected as a main input into our
-priorities. We are expected to always be productive and working on the
+priorities. We're expected to always be productive and working on the
 most worthwhile projects, even when the machines of government produce
 obstacles.
 
@@ -108,7 +107,7 @@ making back-end processing easier.
 
 Our public-facing deliverables must be readable by people with the
 lowest literacy, accessible to people of all abilities, and usable by
-people of all levels of technical proficiency. We’d like our work to be
+people of all levels of technical proficiency. We like our work to be
 sensible, usable, and accessible beyond complying with standards and
 regulations.
 
@@ -128,8 +127,8 @@ your clients through this transition.
 Many of the leases and maintenance contracts are not optimal for
 delivering great service to constituents.
 
-Leadership does not know what APIs are, they don’t understand the value
-of open data, and most of them have little technical knowledge. They are
+Leadership may not know what APIs are, they may be unfamiliar with the value
+of open data, and most of them have little technical knowledge. They're
 risk averse. you'll help them learn, get the vocabulary, and see value
 in changing.
 
@@ -160,7 +159,7 @@ And if it goes well, we will get little or no credit. The agencies we
 work with will be the heroes.
 
 We are a startup with an emerging, changeable culture inside a huge,
-crusty, entrenched organization. It will be frustrating sometimes.
+crusty, entrenched organization. It'll be frustrating sometimes.
 
 Things happen: states sue the federal government to stop programs;
 Congress changes its mind; appropriation bills pass reallocating funds.
@@ -171,7 +170,7 @@ gets stuck by the machines of government.
 
 It’s within the realm of possibility that you’ll be investigated for the
 job you do or a role you have in a project, and that you'll be called to
-testify to a Senate or Congressional committee -- and not to be
+testify to a Senate or Congressional committee — and not to be
 congratulated.
 
 Everything you do, say, write, and make is a public record. Anyone can

--- a/_positions/18F-consulting.md
+++ b/_positions/18F-consulting.md
@@ -82,7 +82,7 @@ the agency. However, most design and development is posted to GitHub
 repositories during development, and is later opened up to the world
 after launch. (Depending on the project, it may be posted publicly
 during development.) Openness extends to open data. We use open data
-when it;s available, and design with the goal of opening up data after
+when it's available, and design with the goal of opening up data after
 launch.
 
 We also collaborate with the public. Many of our deliverables must be

--- a/_positions/acquisition-specialist.md
+++ b/_positions/acquisition-specialist.md
@@ -2,6 +2,7 @@
 title: Acquisition Specialist
 layout: default
 permalink: who-we-are-hiring/positions/acquisition-specialist/
+team: consulting
 ---
 
 As a member of the 18F Consulting team, an Acquisition Specialist

--- a/_positions/agile-coach.md
+++ b/_positions/agile-coach.md
@@ -2,6 +2,7 @@
 title: Agile Coach
 layout: default
 permalink: who-we-are-hiring/positions/agile-coach/
+team: other
 ---
 Experience transforming initiatives to deliver lasting change within
 agencies that focus on delivering value for citizens. Coaches may be
@@ -10,7 +11,7 @@ required to work either:
 -   at the team level, working with teams to ensure that delivery teams
 within agencies are adopting agile and performing effectively
 
--   at the portfolio or program level, to help agencies to establish the
+-   at the portfolio or program level, to help agencies establish the
 right processes for managing a portfolio of work in an agile way
 
 -   at the organization level, to drive strategic change across the
@@ -21,39 +22,39 @@ right processes for managing a portfolio of work in an agile way
     approach to the way in which they govern delivery and continuous
     improvement of digital services
 
-Primarily responsible for:
+## Primarily responsible for:
 
--   Embed an agile culture using techniques from a wide range or agile
-    and lean methodologies and frameworks, but be methodology agnostic
+-   Embed an agile culture using techniques from a wide range of agile
+    and lean methodologies and frameworks, but be methodology agnostic.
 
 -   Help to create an open and trust-based environment, which enables a
-    focus on delivery and facilitates continuous improvement
+    focus on delivery and facilitates continuous improvement.
 
 -   Assess the culture of a team or organization and delivery processes
     in place to identify improvements and facilitate these
-    improvements with the right type of support
+    improvements with the right type of support.
 
 -   Showcase relevant tools and techniques such as coaching, advising,
-    workshops, and mentoring
+    workshops, and mentoring.
 
--   Engage with stakeholders at all levels of the organization
+-   Engage with stakeholders at all levels of the organization.
 
--   Develop clear lines of escalation, in agreement with senior managers
+-   Develop clear lines of escalation, in agreement with senior managers.
 
 -   Ensure any stakeholder can easily find out an accurate and current
-    project or program status, without disruption to delivery
+    project or program status, without disruption to delivery.
 
--   Work effectively with other suppliers and agencies
+-   Work effectively with other suppliers and agencies.
 
 -   Apply best tools and techniques to: team roles, behaviors, structure
     and culture, agile ceremonies and practices, knowledge transfer
     and sharing, program management, cross-team coordination, and
-    overall governance of digital service delivery
+    overall governance of digital service delivery.
 
 -   Ensure key metrics and requirements that support the team and
-    delivery are well defined and maintained
+    delivery are well defined and maintained.
 
--   Equip staff with the ability to coach others
+-   Equip staff with the ability to coach others.
 
--   If organization level, executive coaching on the fundamental
-    considerations of digital service delivery design
+-   If working at the organization level, executive coaching on the fundamental
+    considerations of digital service delivery design.

--- a/_positions/back-end-web-developer.md
+++ b/_positions/back-end-web-developer.md
@@ -1,12 +1,13 @@
 ---
-title: Backend Web Developer
+title: Back End Web Developer
 layout: default
 permalink: who-we-are-hiring/positions/back-end-developer/
+team: engineering
 ---
 
 Experience using modern, open source software to prototype and deploy
-backend web applications, including all aspects of server-side
-processing, data storage, and integration with frontend development.
+back end web applications, including all aspects of server-side
+processing, data storage, and integration with front end development.
 
 Primarily responsible for:
 

--- a/_positions/business-analyst.md
+++ b/_positions/business-analyst.md
@@ -2,6 +2,7 @@
 title: Business Analyst
 layout: default
 permalink: who-we-are-hiring/positions/business-analyst/
+team: delivery
 ---
 
 Familiar with a range of digital/web services and solutions, ideally

--- a/_positions/data-architect.md
+++ b/_positions/data-architect.md
@@ -2,6 +2,7 @@
 title: Data Architect
 layout: default
 permalink: who-we-are-hiring/positions/data-architect/
+team: consulting
 ---
 {
 

--- a/_positions/design-and-product-strategist.md
+++ b/_positions/design-and-product-strategist.md
@@ -2,6 +2,7 @@
 title: Design and Product Strategist
 layout: default
 permalink: who-we-are-hiring/positions/design-and-product-strategist/
+team: consulting
 ---
 The Design and Product Strategist plays an important role on the 18F
 Consulting team. You’re at the forefront of human-centered design and
@@ -32,10 +33,7 @@ project on track.
 Within the first 6-12 months after hiring, you’ll accomplish these
 objectives:
 
-### Objective \#1: Use human-centered methods, empowering agencies with
-the process and tools to examine and discover their challenges and
-opportunities — whether that be for programs, people, products, or
-policies.
+### Objective \#1: Use human-centered methods, empowering agencies with the process and tools to examine and discover their challenges and opportunities — whether that be for programs, people, products, or policies.
 
 -   Plan and lead user research discovery sprints, and facilitate participatory design workshops.
 
@@ -85,8 +83,7 @@ policies.
 
 -   Review proposals from vendors and assess them for design, research, usability testing, and product process acumen.
 
-### Objective \#5: Contribute to creating, assessing, and refining the
-methods 18F uses to deliver its services.
+### Objective \#5: Contribute to creating, assessing, and refining the methods 18F uses to deliver its services.
 
 -   Championing that all aspects of consulting is, in essence, service design, collaborate with all team members to continuously improve the experience and services we provide all our clients, whether that be design, product, technical assessments, or acquisition assistance.
 

--- a/_positions/devops-engineer.md
+++ b/_positions/devops-engineer.md
@@ -2,6 +2,7 @@
 title: DevOps Engineer
 layout: default
 permalink: who-we-are-hiring/positions/devops-engineer/
+team: devops
 ---
 
 Experience serving as the engineer of complex technology implementations

--- a/_positions/digital-performance-analyst.md
+++ b/_positions/digital-performance-analyst.md
@@ -2,6 +2,7 @@
 title: Digital Performance Analyst
 layout: default
 permalink: who-we-are-hiring/positions/digital-performance-analyst/
+team: delivery
 ---
 
 Experience specifying, collecting, and presenting key performance data

--- a/_positions/director-of-technical-architecture.md
+++ b/_positions/director-of-technical-architecture.md
@@ -2,6 +2,7 @@
 title: Director of Technical Architecture
 layout: default
 permalink: who-we-are-hiring/positions/director-of-technical-architecture/
+team: consulting
 ---
 As a senior member of the 18F Consulting team, the Director of Technical
 Architecture leads a group of highly skilled technical
@@ -44,8 +45,7 @@ objectives:
 
 -   Develop a set of *hands-on* consulting services aimed at solving major challenges across the federal government, and market these services to federal agencies.
 
-### Objective \#2: Build, manage, and lead a team of high-performing
-technical architecture/engineering consultants.
+### Objective \#2: Build, manage, and lead a team of high-performing technical architecture/engineering consultants.
 
 -   Based on client demand for services, develop and execute a recruiting strategy for attracting the best and brightest from within and outside of government to join your team.
 

--- a/_positions/engagement-manager.md
+++ b/_positions/engagement-manager.md
@@ -2,6 +2,7 @@
 title: Engagement Manager
 layout: default
 permalink: who-we-are-hiring/positions/engagement-manager/
+team: consulting
 ---
 As a member of the 18F Consulting team, Engagement Managers play the
 critical role of supporting a multi-disciplinary team of highly-skilled 18F experts in
@@ -28,8 +29,7 @@ a few months, and sometimes in just a few days.
 Within the first 6-12 months after hiring, you’ll accomplish these
 objectives:
 
-### Objective \#1: Manage one or more client engagements to improve or
-transform the way they deliver digital/tech services to users.
+### Objective \#1: Manage one or more client engagements to improve or transform the way they deliver digital/tech services to users.
 
 -   Translate the client’s objectives and constraints and 18F’s capacity and capabilities into an engagement approach that will deliver a unique experience and impactful results in the shortest amount of time possible (we don’t want the client to be dependent upon us forever).
 
@@ -45,9 +45,7 @@ transform the way they deliver digital/tech services to users.
 
 -   Measure the qualitative and quantitative impact that 18F made.
 
-### Objective \#2: Constantly improve the way 18F Consulting manages
-client engagements, and actively and openly sharing knowledge of best
-practices.
+### Objective \#2: Constantly improve the way 18F Consulting manages client engagements, and actively and openly sharing knowledge of best practices.
 
 -   Continually conduct retrospectives with clients and members of the 18F Consulting team to learn what is and isn’t working well across the board, and formulate and implement improvement actions.
 

--- a/_positions/front-end-web-developer.md
+++ b/_positions/front-end-web-developer.md
@@ -1,10 +1,11 @@
 ---
-title: Frontend Web Developer
+title: Front End Web Developer
 layout: default
 permalink: who-we-are-hiring/positions/frontend-web-developer/
+team: engineering
 ---
 
-Experience using modern, frontend web development tools, techniques, and
+Experience using modern, front end web development tools, techniques, and
 methods for the creation and deployment of user-facing interfaces. Is
 comfortable working in an agile and lean environment to routinely deploy
 changes.

--- a/_positions/interaction-designer.md
+++ b/_positions/interaction-designer.md
@@ -2,6 +2,7 @@
 title: Interaction Designer / User Researcher / Usability Tester
 layout: default
 permalink: who-we-are-hiring/positions/interaction-design/
+team: delivery
 ---
 
 The Interaction Designer / User Researcher / Usability Tester is part of

--- a/_positions/product-manager.md
+++ b/_positions/product-manager.md
@@ -2,6 +2,7 @@
 title: Product Manager
 layout: default
 permalink: who-we-are-hiring/positions/product-manager/
+team: delivery
 ---
 
 Experience managing the delivery, ongoing success, and continuous

--- a/_positions/security-engineer.md
+++ b/_positions/security-engineer.md
@@ -2,6 +2,7 @@
 title: Security Engineer
 layout: default
 permalink: who-we-are-hiring/positions/security-engineer/
+team: devops
 ---
 
 Experience serving as the security engineer of complex technology

--- a/_positions/technical-architect.md
+++ b/_positions/technical-architect.md
@@ -74,8 +74,7 @@ objectives:
 
 -   Provide consulting and hands-on support throughout each of the infrastructure migration phases, including assessment, proof of concept, data migration, application migration, and optimization.
 
-### Objective \#4: Promote the adoption of modern technology practices
-through teaching, coaching, and knowledge sharing.
+### Objective \#4: Promote the adoption of modern technology practices through teaching, coaching, and knowledge sharing.
 
 -   Conduct one or more agile workshops to accelerate the learning and adoption of agile development principles and practices.
 

--- a/_positions/technical-architect.md
+++ b/_positions/technical-architect.md
@@ -2,6 +2,7 @@
 title: Technical Architect
 layout: default
 permalink: who-we-are-hiring/positions/technical-architect/
+team: consulting
 ---
 As a member of the 18F Consulting team, Technical Architects face the
 daunting challenge of bridging the gap between two technological worlds
@@ -49,8 +50,7 @@ objectives:
 
 -   Oversee the implementation of the architecture strategy.
 
-### Objective \#2: Serve as the technical leader on a large digital/IT
-project, similar in size and importance to Healthcare.gov.
+### Objective \#2: Serve as the technical leader on a large digital/IT project, similar in size and importance to Healthcare.gov.
 
 -   Architect the overall system, by using prototyping and proof of concepts, with an eye toward constant reengineering and refactoring to ensure the simplest and most elegant system possible to accomplish the desired need.
 
@@ -70,8 +70,7 @@ project, similar in size and importance to Healthcare.gov.
 
 -   Liberally share knowledge across a multi-disciplinary team and work within agile methodologies.
 
-### Objective \#3: Begin migrating a large IT organization to
-Infrastructure as a Service (IaaS) providers.
+### Objective \#3: Begin migrating a large IT organization to Infrastructure as a Service (IaaS) providers.
 
 -   Provide consulting and hands-on support throughout each of the infrastructure migration phases, including assessment, proof of concept, data migration, application migration, and optimization.
 

--- a/_positions/visual-designer.md
+++ b/_positions/visual-designer.md
@@ -2,6 +2,7 @@
 title: Visual Designer
 layout: default
 permalink: who-we-are-hiring/positions/visual-designer/
+team: design
 ---
 
 The Visual Designer starts with a deep understanding of the goals of

--- a/_positions/writer-content-designer-strategist.md
+++ b/_positions/writer-content-designer-strategist.md
@@ -2,6 +2,7 @@
 title: Writer / Content Designer / Content Strategist
 layout: default
 permalink: who-we-are-hiring/positions/content-designer/
+team: outreach
 ---
 
 Experience developing the strategy and execution of content across

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 permalink: /
 layout: default
-title: So You Want to Join 18F?
+title: So you want to join 18F?
 ---
 
 ## Mission
@@ -17,6 +17,3 @@ We will accomplish our mission by:
 * putting the needs of the public first
 * being design-centric, agile, open, and data-driven
 * deploying tools and services early and often
-
-
-

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -13,8 +13,58 @@ Everywhere in the United States! If you have no experience working on remote tea
 
 Our rapidly growing team is home to a variety of roles, including these:
 
+<h3>Delivery</h3>
 <ul>
-{% for position in site.positions %}
-	<li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% assign positions = site.positions | where:"team","delivery" %}
+{% for position in positions %}
+    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% endfor %}
+</ul>
+
+<h3>Engineering</h3>
+<ul>
+{% assign positions = site.positions | where:"team","engineering" %}
+{% for position in positions %}
+    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% endfor %}
+</ul>
+
+<h3>DevOps</h3>
+<ul>
+{% assign positions = site.positions | where:"team","devops" %}
+{% for position in positions %}
+    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% endfor %}
+</ul>
+
+<h3>Consulting</h3>
+<ul>
+{% assign positions = site.positions | where:"team","consulting" %}
+{% for position in positions %}
+    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% endfor %}
+</ul>
+
+<h3>Design</h3>
+<ul>
+{% assign positions = site.positions | where:"team","design" %}
+{% for position in positions %}
+    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% endfor %}
+</ul>
+
+<h3>Outreach</h3>
+<ul>
+{% assign positions = site.positions | where:"team","outreach" %}
+{% for position in positions %}
+    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% endfor %}
+</ul>
+
+<h3>Other</h3>
+<ul>
+{% assign positions = site.positions | where:"team","other" %}
+{% for position in positions %}
+    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
Also fixed style and formatting errors. Reorganized the Who We Are Hiring page into team lists. Positions descriptions still need more editing to conform to 18F style, but this gets them closer. 
