### PR TITLE
Added way to temp remove positions

### DIFF
--- a/_includes/positionslist.html
+++ b/_includes/positionslist.html
@@ -1,0 +1,9 @@
+{% assign positions = site.positions | where:"team",include.team | where:"active",true %}
+{% unless positions.size == 0 %}
+<h3>{{include.title}}</h3>
+<ul>
+{% for position in positions %}
+    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
+{% endfor %}
+</ul>
+{% endunless %}

--- a/_positions/18F-consulting.md
+++ b/_positions/18F-consulting.md
@@ -3,6 +3,7 @@ title: General information about 18F Consulting
 layout: default
 permalink: who-we-are-hiring/positions/18f-consulting/
 team: consulting
+active: true
 ---
 ## Management and organization structure
 

--- a/_positions/acquisition-specialist.md
+++ b/_positions/acquisition-specialist.md
@@ -3,6 +3,7 @@ title: Acquisition Specialist
 layout: default
 permalink: who-we-are-hiring/positions/acquisition-specialist/
 team: consulting
+active: true
 ---
 
 As a member of the 18F Consulting team, an Acquisition Specialist

--- a/_positions/agile-coach.md
+++ b/_positions/agile-coach.md
@@ -3,6 +3,7 @@ title: Agile Coach
 layout: default
 permalink: who-we-are-hiring/positions/agile-coach/
 team: other
+active: true
 ---
 Experience transforming initiatives to deliver lasting change within
 agencies that focus on delivering value for citizens. Coaches may be

--- a/_positions/back-end-web-developer.md
+++ b/_positions/back-end-web-developer.md
@@ -3,6 +3,7 @@ title: Back End Web Developer
 layout: default
 permalink: who-we-are-hiring/positions/back-end-developer/
 team: engineering
+active: true
 ---
 
 Experience using modern, open source software to prototype and deploy

--- a/_positions/business-analyst.md
+++ b/_positions/business-analyst.md
@@ -3,6 +3,7 @@ title: Business Analyst
 layout: default
 permalink: who-we-are-hiring/positions/business-analyst/
 team: delivery
+active: true
 ---
 
 Familiar with a range of digital/web services and solutions, ideally

--- a/_positions/data-architect.md
+++ b/_positions/data-architect.md
@@ -3,6 +3,7 @@ title: Data Architect
 layout: default
 permalink: who-we-are-hiring/positions/data-architect/
 team: consulting
+active: true
 ---
 {
 

--- a/_positions/delivery-manager.md
+++ b/_positions/delivery-manager.md
@@ -2,6 +2,8 @@
 title: Delivery Manager
 layout: default
 permalink: who-we-are-hiring/positions/delivery-manager/
+team: delivery
+active: true
 ---
 
 Experience setting up teams for successful delivery by removing

--- a/_positions/design-and-product-strategist.md
+++ b/_positions/design-and-product-strategist.md
@@ -3,6 +3,7 @@ title: Design and Product Strategist
 layout: default
 permalink: who-we-are-hiring/positions/design-and-product-strategist/
 team: consulting
+active: true
 ---
 The Design and Product Strategist plays an important role on the 18F
 Consulting team. You’re at the forefront of human-centered design and

--- a/_positions/devops-engineer.md
+++ b/_positions/devops-engineer.md
@@ -3,6 +3,7 @@ title: DevOps Engineer
 layout: default
 permalink: who-we-are-hiring/positions/devops-engineer/
 team: devops
+active: true
 ---
 
 Experience serving as the engineer of complex technology implementations

--- a/_positions/digital-performance-analyst.md
+++ b/_positions/digital-performance-analyst.md
@@ -3,6 +3,7 @@ title: Digital Performance Analyst
 layout: default
 permalink: who-we-are-hiring/positions/digital-performance-analyst/
 team: delivery
+active: true
 ---
 
 Experience specifying, collecting, and presenting key performance data

--- a/_positions/director-of-technical-architecture.md
+++ b/_positions/director-of-technical-architecture.md
@@ -3,6 +3,7 @@ title: Director of Technical Architecture
 layout: default
 permalink: who-we-are-hiring/positions/director-of-technical-architecture/
 team: consulting
+active: true
 ---
 As a senior member of the 18F Consulting team, the Director of Technical
 Architecture leads a group of highly skilled technical

--- a/_positions/engagement-manager.md
+++ b/_positions/engagement-manager.md
@@ -3,6 +3,7 @@ title: Engagement Manager
 layout: default
 permalink: who-we-are-hiring/positions/engagement-manager/
 team: consulting
+active: true
 ---
 As a member of the 18F Consulting team, Engagement Managers play the
 critical role of supporting a multi-disciplinary team of highly-skilled 18F experts in
@@ -24,7 +25,7 @@ use, but in turn affects how government works. Depending on the nature
 of the work and the methods that you use, you can affect change in just
 a few months, and sometimes in just a few days.
 
-## Key Objectives 
+## Key Objectives
 
 Within the first 6-12 months after hiring, you’ll accomplish these
 objectives:

--- a/_positions/front-end-web-developer.md
+++ b/_positions/front-end-web-developer.md
@@ -3,6 +3,7 @@ title: Front End Web Developer
 layout: default
 permalink: who-we-are-hiring/positions/frontend-web-developer/
 team: engineering
+active: true
 ---
 
 Experience using modern, front end web development tools, techniques, and

--- a/_positions/interaction-designer.md
+++ b/_positions/interaction-designer.md
@@ -3,6 +3,7 @@ title: Interaction Designer / User Researcher / Usability Tester
 layout: default
 permalink: who-we-are-hiring/positions/interaction-design/
 team: delivery
+active: true
 ---
 
 The Interaction Designer / User Researcher / Usability Tester is part of

--- a/_positions/product-manager.md
+++ b/_positions/product-manager.md
@@ -3,6 +3,7 @@ title: Product Manager
 layout: default
 permalink: who-we-are-hiring/positions/product-manager/
 team: delivery
+active: true
 ---
 
 Experience managing the delivery, ongoing success, and continuous

--- a/_positions/security-engineer.md
+++ b/_positions/security-engineer.md
@@ -3,6 +3,7 @@ title: Security Engineer
 layout: default
 permalink: who-we-are-hiring/positions/security-engineer/
 team: devops
+active: true
 ---
 
 Experience serving as the security engineer of complex technology

--- a/_positions/technical-architect.md
+++ b/_positions/technical-architect.md
@@ -3,6 +3,7 @@ title: Technical Architect
 layout: default
 permalink: who-we-are-hiring/positions/technical-architect/
 team: consulting
+active: true
 ---
 As a member of the 18F Consulting team, Technical Architects face the
 daunting challenge of bridging the gap between two technological worlds

--- a/_positions/visual-designer.md
+++ b/_positions/visual-designer.md
@@ -3,6 +3,7 @@ title: Visual Designer
 layout: default
 permalink: who-we-are-hiring/positions/visual-designer/
 team: design
+active: true
 ---
 
 The Visual Designer starts with a deep understanding of the goals of

--- a/_positions/writer-content-designer-strategist.md
+++ b/_positions/writer-content-designer-strategist.md
@@ -3,6 +3,7 @@ title: Writer / Content Designer / Content Strategist
 layout: default
 permalink: who-we-are-hiring/positions/content-designer/
 team: outreach
+active: true
 ---
 
 Experience developing the strategy and execution of content across

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -3,11 +3,11 @@ title: Who are we hiring?
 layout: default
 permalink: /who-we-are-hiring/
 ---
-We're looking for candidates who are passionate about our mission, with top-notch software development, design, content, and operations skills to match. Below you will find a list of our current job openings. 
+We're looking for candidates who are passionate about our mission, with top-notch software development, design, content, and operations skills to match. Below you will find a list of our current job openings.
 
-## Do I have to be a citizen to work at 18F? 
+## Do I have to be a citizen to work at 18F?
 
-If you can legally work in the U.S. then you are eligible to work for 18F. You do not have to be a U.S. citizen, but our agency is unable to sponsor visas, so you must already be able to work in the U.S. 
+If you can legally work in the U.S. then you are eligible to work for 18F. You do not have to be a U.S. citizen, but our agency is unable to sponsor visas, so you must already be able to work in the U.S.
 
 ## Where are we hiring?
 
@@ -15,59 +15,16 @@ Everywhere in the United States! If you have no experience working on remote tea
 
 ## Open positions
 
-<h3>Consulting</h3>
-<ul>
-{% assign positions = site.positions | where:"team","consulting" %}
-{% for position in positions %}
-    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
-{% endfor %}
-</ul>
+{% include positionslist.html team="delivery" title="Delivery" %}
 
-<h3>Delivery</h3>
-<ul>
-{% assign positions = site.positions | where:"team","delivery" %}
-{% for position in positions %}
-    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
-{% endfor %}
-</ul>
+{% include positionslist.html team="design" title="Design" %}
 
-<h3>Design</h3>
-<ul>
-{% assign positions = site.positions | where:"team","design" %}
-{% for position in positions %}
-    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
-{% endfor %}
-</ul>
+{% include positionslist.html team="devops" title="DevOps" %}
 
-<h3>DevOps</h3>
-<ul>
-{% assign positions = site.positions | where:"team","devops" %}
-{% for position in positions %}
-    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
-{% endfor %}
-</ul>
+{% include positionslist.html team="consulting" title="Consulting" %}
 
+{% include positionslist.html team="engineering" title="Engineering" %}
 
-<h3>Engineering</h3>
-<ul>
-{% assign positions = site.positions | where:"team","engineering" %}
-{% for position in positions %}
-    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
-{% endfor %}
-</ul>
+{% include positionslist.html team="other" title="Other" %}
 
-<h3>Outreach</h3>
-<ul>
-{% assign positions = site.positions | where:"team","outreach" %}
-{% for position in positions %}
-    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
-{% endfor %}
-</ul>
-
-<h3>Other</h3>
-<ul>
-{% assign positions = site.positions | where:"team","other" %}
-{% for position in positions %}
-    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
-{% endfor %}
-</ul>
+{% include positionslist.html team="outreach" title="Outreach" %}


### PR DESCRIPTION
Now each positions has a 'team' and and 'active' attribute in the front matter. To temporarily hide a position, like if it's filled, just change the 'active' attribute to 'false'. If a team has no open positions, it will automatically be removed from the Who are we hiring page. 
