### PR TITLE
removing positions not open

### DIFF
--- a/_positions/business-analyst.md
+++ b/_positions/business-analyst.md
@@ -3,7 +3,7 @@ title: Business Analyst
 layout: default
 permalink: who-we-are-hiring/positions/business-analyst/
 team: delivery
-active: true
+active: false
 ---
 
 Familiar with a range of digital/web services and solutions, ideally

--- a/_positions/delivery-manager.md
+++ b/_positions/delivery-manager.md
@@ -3,7 +3,7 @@ title: Delivery Manager
 layout: default
 permalink: who-we-are-hiring/positions/delivery-manager/
 team: delivery
-active: true
+active: false
 ---
 
 Experience setting up teams for successful delivery by removing

--- a/_positions/digital-performance-analyst.md
+++ b/_positions/digital-performance-analyst.md
@@ -3,7 +3,7 @@ title: Digital Performance Analyst
 layout: default
 permalink: who-we-are-hiring/positions/digital-performance-analyst/
 team: delivery
-active: true
+active: false
 ---
 
 Experience specifying, collecting, and presenting key performance data

--- a/_positions/interaction-designer.md
+++ b/_positions/interaction-designer.md
@@ -2,7 +2,7 @@
 title: Interaction Designer / User Researcher / Usability Tester
 layout: default
 permalink: who-we-are-hiring/positions/interaction-design/
-team: delivery
+team: design
 active: true
 ---
 

--- a/_positions/writer-content-designer-strategist.md
+++ b/_positions/writer-content-designer-strategist.md
@@ -3,7 +3,7 @@ title: Writer / Content Designer / Content Strategist
 layout: default
 permalink: who-we-are-hiring/positions/content-designer/
 team: outreach
-active: true
+active: false
 ---
 
 Experience developing the strategy and execution of content across


### PR DESCRIPTION
Per issue #25 removes business analyst, digital performance analyst, content, and delivery manager. Puts interaction designer under design
