### PR TITLE
minor menu highlighting fix

### DIFF
--- a/pages/interview-process.md
+++ b/pages/interview-process.md
@@ -1,7 +1,7 @@
 ---
 permalink: /interview-process/
 layout: default
-title: The 18F interview process
+title: Interview process
 ---
 
 ### Phone screen

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -1,15 +1,15 @@
 ---
-title: Who are we hiring?
+title: Who we are hiring
 layout: default
 permalink: /who-we-are-hiring/
 ---
 We're looking for candidates who are passionate about our mission, with top-notch software development, design, content, and operations skills to match. Below you will find a list of our current job openings.
 
-## Who is eligible to work at 18F?
+## Who is eligible to work at 18F
 
 U.S. citizens, non-citizens who are nationals of the U.S., or people who have been admitted to the U.S. for permanent residence and hold a valid green card.
 
-## Where are we hiring?
+## Where are we hiring
 
 Everywhere in the United States! If you have no experience working on remote teams or are applying for a role that requires in-person interactions with clients, we'll ask you to work out of our San Francisco or D.C. office. However, the majority of our team is distributed across the country in places like Chicago, New York, Raleigh, Tuscon, Austin, Dayton, Philadelphia, Santa Barbara, Seattle, and Portland.
 


### PR DESCRIPTION
This PR fixes menu highlight. Apparently the link and the title have to match exactly for the highlight to be active. I had to take out the `?` of `who are we hiring` and as well as `The 18F` out of `Interview process`. 

When creating new pages `url === title` :smile: Thanks to @nickbristow for the heads up. 
