### PR TITLE
Adds inactive positions in separate section

### DIFF
--- a/_includes/inactivepositions.html
+++ b/_includes/inactivepositions.html
@@ -1,9 +1,4 @@
-{% assign positions = site.positions | where:"active",false | group_by:"team" %}
-{% for position in positions %}
-<h3>{{ position['name'] |capitalize}}</h3>
+{% assign positions = site.positions | where:"active",false | group_by:"team" %}{% for position in positions %}<h3>{{ position['name'] |capitalize}}</h3>
 <ul>
-{% for item in position['items'] %}
-  <li><a href="{{site.baseurl}}{{item.url}}">{{ item.title }}</a></li>
-  {% endfor %}
-</ul>
-{% endfor %}
+  {% for item in position['items'] %}<li><a href="{{site.baseurl}}{{item.url}}">{{ item.title }}</a></li>{% endfor %}
+</ul>{% endfor %}

--- a/_includes/inactivepositions.html
+++ b/_includes/inactivepositions.html
@@ -1,0 +1,9 @@
+{% assign positions = site.positions | where:"active",false | group_by:"team" %}
+{% for position in positions %}
+<h3>{{ position['name'] |capitalize}}</h3>
+<ul>
+{% for item in position['items'] %}
+  <li><a href="{{site.baseurl}}{{item.url}}">{{ item.title }}</a></li>
+  {% endfor %}
+</ul>
+{% endfor %}

--- a/_includes/openpositions.html
+++ b/_includes/openpositions.html
@@ -1,7 +1,5 @@
 {% assign positions = site.positions | where:"active",true | group_by:"team" %}
-{% for position in positions %}
-<h3>{{ position['name'] |capitalize}}</h3>
+{% for position in positions %}<h3>{{ position['name'] |capitalize}}</h3>
 <ul>
   {% for item in position['items'] %}<li><a href="{{site.baseurl}}{{item.url}}">{{ item.title }}</a></li>{% endfor %}
-</ul>
-{% endfor %}
+</ul>{% endfor %}

--- a/_includes/openpositions.html
+++ b/_includes/openpositions.html
@@ -1,0 +1,7 @@
+{% assign positions = site.positions | where:"active",true | group_by:"team" %}
+{% for position in positions %}
+<h3>{{ position['name'] |capitalize}}</h3>
+<ul>
+  {% for item in position['items'] %}<li><a href="{{site.baseurl}}{{item.url}}">{{ item.title }}</a></li>{% endfor %}
+</ul>
+{% endfor %}

--- a/_includes/positionslist.html
+++ b/_includes/positionslist.html
@@ -1,5 +1,0 @@
-{% if include.active == "true" %}{% assign positions = site.positions | where:"team",include.team | where:"active",true %}{% else %}{% assign positions = site.positions | where:"team", include.team | where:"active", false %}{% endif %}{% unless positions.size == 0 %}
-<h3>{{include.title}}</h3>
-<ul>
-{% for position in positions %}<li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>{% endfor %}
-</ul>{% endunless %}

--- a/_includes/positionslist.html
+++ b/_includes/positionslist.html
@@ -1,13 +1,5 @@
-{% if include.active == "true" %}
-{% assign positions = site.positions | where:"team",include.team | where:"active",true %}
-{% else %}
-{% assign positions = site.positions | where:"team", include.team | where:"active", false %}
-{% endif %}
-{% unless positions.size == 0 %}
+{% if include.active == "true" %}{% assign positions = site.positions | where:"team",include.team | where:"active",true %}{% else %}{% assign positions = site.positions | where:"team", include.team | where:"active", false %}{% endif %}{% unless positions.size == 0 %}
 <h3>{{include.title}}</h3>
 <ul>
-{% for position in positions %}
-    <li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>
-{% endfor %}
-</ul>
-{% endunless %}
+{% for position in positions %}<li><a href="{{site.baseurl}}{{ position.url }}">{{ position.title }}</a></li>{% endfor %}
+</ul>{% endunless %}

--- a/_includes/positionslist.html
+++ b/_includes/positionslist.html
@@ -1,4 +1,8 @@
+{% if include.active == "true" %}
 {% assign positions = site.positions | where:"team",include.team | where:"active",true %}
+{% else %}
+{% assign positions = site.positions | where:"team", include.team | where:"active", false %}
+{% endif %}
 {% unless positions.size == 0 %}
 <h3>{{include.title}}</h3>
 <ul>

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -17,8 +17,8 @@ Everywhere in the United States! If you have no experience working on remote tea
 
 Check back in mid-September for a more complete list of performance profiles that will provide more clarity on the talent we're seeking for 18F. Until then, we’re in critical need of candidates for the following positions:
 
-{% include openpositions.html teams="all" %}
+{% include openpositions.html %}
 
 ## Inactive positions
 
-{% include inactivepositions.html teams="all" %}
+{% include inactivepositions.html %}

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -17,16 +17,32 @@ Everywhere in the United States! If you have no experience working on remote tea
 
 Check back in mid-September for a more complete list of performance profiles that will provide more clarity on the talent we're seeking for 18F. Until then, we’re in critical need of candidates for the following positions:
 
-{% include positionslist.html team="delivery" title="Delivery" %}
+{% include positionslist.html team="delivery" title="Delivery"  active="true"%}
 
-{% include positionslist.html team="design" title="Design" %}
+{% include positionslist.html team="design" title="Design"  active="true"%}
 
-{% include positionslist.html team="devops" title="DevOps" %}
+{% include positionslist.html team="devops" title="DevOps"  active="true"%}
 
-{% include positionslist.html team="consulting" title="Consulting" %}
+{% include positionslist.html team="consulting" title="Consulting"  active="true"%}
 
-{% include positionslist.html team="engineering" title="Engineering" %}
+{% include positionslist.html team="engineering" title="Engineering"  active="true"%}
 
-{% include positionslist.html team="other" title="Other" %}
+{% include positionslist.html team="other" title="Other"  active="true"%}
 
-{% include positionslist.html team="outreach" title="Outreach" %}
+{% include positionslist.html team="outreach" title="Outreach" active="true" %}
+
+## Inactive positions
+
+{% include positionslist.html team="delivery" title="Delivery" active="false" %}
+
+{% include positionslist.html team="design" title="Design" active="false" %}
+
+{% include positionslist.html team="devops" title="DevOps" active="false" %}
+
+{% include positionslist.html team="consulting" title="Consulting" active="false" %}
+
+{% include positionslist.html team="engineering" title="Engineering" active="false" %}
+
+{% include positionslist.html team="other" title="Other" active="false" %}
+
+{% include positionslist.html team="outreach" title="Outreach" active="false" %}

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -17,32 +17,8 @@ Everywhere in the United States! If you have no experience working on remote tea
 
 Check back in mid-September for a more complete list of performance profiles that will provide more clarity on the talent we're seeking for 18F. Until then, we’re in critical need of candidates for the following positions:
 
-{% include positionslist.html team="delivery" title="Delivery"  active="true"%}
-
-{% include positionslist.html team="design" title="Design"  active="true"%}
-
-{% include positionslist.html team="devops" title="DevOps"  active="true"%}
-
-{% include positionslist.html team="consulting" title="Consulting"  active="true"%}
-
-{% include positionslist.html team="engineering" title="Engineering"  active="true"%}
-
-{% include positionslist.html team="other" title="Other"  active="true"%}
-
-{% include positionslist.html team="outreach" title="Outreach" active="true" %}
+{% include openpositions.html teams="all" %}
 
 ## Inactive positions
 
-{% include positionslist.html team="delivery" title="Delivery" active="false" %}
-
-{% include positionslist.html team="design" title="Design" active="false" %}
-
-{% include positionslist.html team="devops" title="DevOps" active="false" %}
-
-{% include positionslist.html team="consulting" title="Consulting" active="false" %}
-
-{% include positionslist.html team="engineering" title="Engineering" active="false" %}
-
-{% include positionslist.html team="other" title="Other" active="false" %}
-
-{% include positionslist.html team="outreach" title="Outreach" active="false" %}
+{% include inactivepositions.html teams="all" %}


### PR DESCRIPTION
Separates out open and closed positions into two lists, each list sorted by teams. 

Listing all positions helps promote transparency, assists in shipping culture for other agencies to start digital teams, and provides additional information to potential candidates. 

<strike>This solution no longer allows for positions descriptions to be easily hid while retaining the file in the repo. </strike> Each position has `active:` in the frontmatter. Setting this to anything other than `true` or `false` will effectively hide it from the page.
