### PR TITLE
DRY out application instructions

### DIFF
--- a/pages/interview-process.md
+++ b/pages/interview-process.md
@@ -6,7 +6,7 @@ title: Interview process
 
 ### Phone screen
 
-[Apply to 18F](/how-to-apply). Within three weeks our team will review your resume, and if you seem like a good fit, we'll reach out to schedule a 30-minute phone call. Plan to talk about your skills and experience, what you're passionate about, and the work we do here. 
+[Apply to 18F]({{ site.baseurl }}/how-to-apply/). Within three weeks our team will review your resume, and if you seem like a good fit, we'll reach out to schedule a 30-minute phone call. Plan to talk about your skills and experience, what you're passionate about, and the work we do here. 
 
 ### In-person (or videochat) interviews
 

--- a/pages/interview-process.md
+++ b/pages/interview-process.md
@@ -6,7 +6,7 @@ title: Interview process
 
 ### Phone screen
 
-Apply to 18F by emailing your resume to [join18f@gsa.gov](mailto:join18f@gsa.gov). Within three weeks our team will review your resume, and if you seem like a good fit, we'll reach out to schedule a 30-minute phone call. Plan to talk about your skills and experience, what you're passionate about, and the work we do here. 
+[Apply to 18F](/how-to-apply). Within three weeks our team will review your resume, and if you seem like a good fit, we'll reach out to schedule a 30-minute phone call. Plan to talk about your skills and experience, what you're passionate about, and the work we do here. 
 
 ### In-person (or videochat) interviews
 


### PR DESCRIPTION
Direct all applicants to the 'How to Apply' page so any important information there, including instructions related to #54, reaches them.

@arowla, sending this to you for review. There must be a more robust way to construct this link.
