### PR TITLE
take out phrase about remote experience

### DIFF
--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -13,7 +13,7 @@ We’re building a team that looks like the United States, and we don't discrimi
 
 ## Where we are hiring
 
-Everywhere in the United States! Most of our team is distributed across the country in places like Chicago, New York, Raleigh, Tucson, Austin, Dayton, Philadelphia, San Diego, Seattle, and Portland. [Read more about how our work culture supports distributed teams.](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/) If you are applying for a role that requires a large number of in-person interactions with clients, we'll ask you to work out of our offices in San Francisco or D.C.
+Everywhere in the United States! Most of our team is distributed across the country in places like Chicago, New York, Raleigh, Tucson, Austin, Dayton, Philadelphia, San Diego, Seattle, and Portland. [Read more about how our work culture supports distributed teams.](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/) In some cases we'll ask you to work out of our offices in San Francisco, Chicago or D.C.
 
 ## Upcoming positions
 We're currently revamping our application process. When it relaunches in mid-November, we will be hiring for positions including the following:

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -13,7 +13,7 @@ We’re building a team that looks like the United States, and we don't discrimi
 
 ## Where we are hiring
 
-Everywhere in the United States! Most of our team is distributed across the country in places like Chicago, New York, Raleigh, Tucson, Austin, Dayton, Philadelphia, San Diego, Seattle, and Portland. [Read more about how our work culture supports distributed teams.](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/) If you have no experience working on remote teams or are applying for a role that requires in-person interactions with clients, we'll ask you to work out of our offices in San Francisco or D.C.
+Everywhere in the United States! Most of our team is distributed across the country in places like Chicago, New York, Raleigh, Tucson, Austin, Dayton, Philadelphia, San Diego, Seattle, and Portland. [Read more about how our work culture supports distributed teams.](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/) If you are applying for a role that requires a large number of in-person interactions with clients, we'll ask you to work out of our offices in San Francisco or D.C.
 
 ## Upcoming positions
 We're currently revamping our application process. When it relaunches in mid-November, we will be hiring for positions including the following:


### PR DESCRIPTION
Relatively few people in the world have remote work experience, and many aren't open to relocation. I think we're doing ourselves a disservice by automatically filtering out those candidates. If we want a hedge, we could say something like "you may be asked to work out of one of our offices".

Also, would working in SF actually help in terms of proximity to clients?
