### PR TITLE
Change application link, remove USDS

### DIFF
--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -4,9 +4,7 @@ title: How to apply
 ---
 If you are interested in joining 18F, use the application link below. This page also contains other information about the application process.
 
-|** Apply Here**|
-|:---:|
-|[<strong>18F Application</strong>](/joining-18f/pages/apply.html)|
+##[Apply to join 18F](/joining-18f/pages/apply.html)|
 
 
 If you have any questions, please reach our Talent Team at [join18f@gsa.gov](mailto:join18f@gsa.gov).

--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -2,12 +2,12 @@
 permalink: /how-to-apply/
 title: How to apply
 ---
+If you are interested in joining 18F, use the application link below. This page also contains other information about the application process.
 
-18F and the U.S. Digital Service are distinct groups working toward the same goals. 18F is a digital consultancy within the General Services Administration (GSA). We develop products for other agencies, and those agencies pay for our services. In contrast, the U.S. Digital Service is headquartered inside the Office of Management and Budget. They support and coordinate the work of various digital service teams housed in agencies across the federal government.
+|** Apply Here**|
+|:---:|
+|[<strong>18F Application</strong>](/joining-18f/pages/apply.html)|
 
-[<strong>Apply directly to 18F</strong>](/joining-18f/pages/apply.html)! Questions? Email [join18f@gsa.gov](mailto:join18f@gsa.gov).
-
-If you want to be considered for the full U.S. Digital Service family and other agencies, submit your application on the [USDS website](https://www.whitehouse.gov/digital/united-states-digital-service/apply). Enter "join18F" as the referral code.
 
 If you have any questions, please reach our Talent Team at [join18f@gsa.gov](mailto:join18f@gsa.gov).
 

--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -2,7 +2,6 @@
 permalink: /how-to-apply/
 title: How to apply
 ---
-If you are interested in joining 18F, use the application link below. This page also contains other information about the application process.
 
 ##[Apply to join 18F](https://pages.18f.gov/joining-18f/pages/apply.html)
 

--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -4,7 +4,7 @@ title: How to apply
 ---
 If you are interested in joining 18F, use the application link below. This page also contains other information about the application process.
 
-##[Apply to join 18F](/joining-18f/pages/apply.html)|
+##[Apply to join 18F](https://pages.18f.gov/joining-18f/pages/apply.html)
 
 
 If you have any questions, please reach our Talent Team at [join18f@gsa.gov](mailto:join18f@gsa.gov).


### PR DESCRIPTION
Changing the formatting on the link for clarity. Also, removing the USDS language. It feels confusing that we are directing the user to USDS immediately after our application. We should create a page to house all the information for the coalition instead of on our how to apply page.
