### PR TITLE
Change referral code when directing applicants to USDS

### DIFF
--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -7,7 +7,7 @@ title: How to apply
 
 [<strong>Apply directly to 18F</strong>](/joining-18f/pages/apply.html)! Questions? Email [join18f@gsa.gov](mailto:join18f@gsa.gov).
 
-If you want to be considered for the full U.S. Digital Service family and other agencies, submit your application on the [USDS website](https://www.whitehouse.gov/digital/united-states-digital-service/apply). Enter "join18F" as the referral code.
+If you want to be considered for the full U.S. Digital Service family and other agencies, submit your application on the [USDS website](https://www.whitehouse.gov/digital/united-states-digital-service/). Enter "18F" as the referral code.
 
 If you have any questions, please reach our Talent Team at [join18f@gsa.gov](mailto:join18f@gsa.gov).
 


### PR DESCRIPTION
@JenTress -- When referring people from 18F to USDS, I propose changing the referral code from "join18F" (which is confusing, since implied in the referral is that they are considering joining USDS) to simply "18F".

I also changed the USDS link to go to our main page (before the application itself) so applicants get more context before applying.
