### PR TITLE
Info re-org Who we hire -> How to Apply

### DIFF
--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -8,6 +8,18 @@ title: How to apply
 
 If you have any questions, please reach our Talent Team at [join18f@gsa.gov](mailto:join18f@gsa.gov).
 
+## Who is eligible to work at 18F
+
+Any individual who is not currently a GSA employee or contractor and who is a U.S. Citizen, a non-citizen national of the U.S., or has been admitted to the U.S. for permanent residence and holds a valid green card is eligible to apply.
+
+## 18F is an Equal Opportunity Employer
+We’re building a team that looks like the United States, and we don't discriminate based on race, color, religion, sex, gender identity or expression, national origin, political affiliation, sexual orientation, marital status, disability, genetic information, age, membership in an employee organization, retaliation, parental status, military service, or other non-merit factor. If you have the skills we need, that’s all that matters.
+
+## Where we are hiring
+
+Everywhere in the United States! Most of our team is distributed across the country in places like Chicago, New York, Raleigh, Tucson, Austin, Dayton, Philadelphia, San Diego, Seattle, and Portland. [Read more about how our work culture supports distributed teams.](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/) In some cases we'll ask you to work out of our offices in San Francisco, Chicago or D.C.
+
+
 ## Documents required for the hiring process
 
 **When you apply, you’ll need to include a current, government-style resume.** Government-style resumes are very different from private-sector resumes. [Here is a guide](http://gogovernment.org/how_to_apply/write_your_federal_resume/create_your_resume.php) and some [example](http://www.fda.gov/downloads/AboutFDA/WorkingatFDA/UCM279014.pdf) [resumes](http://www.jobs.irs.gov/downloads/ResumeTips.pdf). Please overexplain, include dates of each engagement, and include everything and the kitchen sink.


### PR DESCRIPTION
Potential solution to creating a separate page that houses only the teams and roles. This prevents the need for the addition of another page.

Moving Eligibility, Equal Opp and Where hiring to the How to Apply page. Making room on the Who we are Hiring to house only the information about teams and roles.
