### PR TITLE
Relative URLs via {{ site.baseurl }}

### DIFF
--- a/_positions/acquisition-specialist.md
+++ b/_positions/acquisition-specialist.md
@@ -24,4 +24,4 @@ As an 18F acquisition specialist, you’ll need to possess two key qualities: ex
 - Write blog posts on the 18F blog on important acquisition topics and client case studies. (You can see our previous blog posts about procurement [here](https://18f.gsa.gov/tags/procurement/).)
 
 
-[Read more about management and organization structure, environmental challenges and needs, and basic employment requirements for this position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+[Read more about management and organization structure, environmental challenges and needs, and basic employment requirements for this position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/data-architect.md
+++ b/_positions/data-architect.md
@@ -29,4 +29,4 @@ The federal government has hundreds of thousands of data sets, and managing that
 - Help curate our team’s internal data, focusing on how to collect, maintain, and publish it. 
 - Use data to identify alternative methods of approaching and understanding our clients’ needs.
 
-[Read more about management and organization structure, environmental challenges and needs, and basic employment requirements for this position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+[Read more about management and organization structure, environmental challenges and needs, and basic employment requirements for this position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/design-and-product-strategist.md
+++ b/_positions/design-and-product-strategist.md
@@ -95,4 +95,4 @@ objectives:
 
 [Read more about management and organization structure, environmental
 challenges and needs, and basic employment requirements for this
-position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/director-of-biz-dev-and-products.md
+++ b/_positions/director-of-biz-dev-and-products.md
@@ -38,4 +38,4 @@ Within the first 6-12 months after hiring, you’ll accomplish these objectives:
 
 [Read more about management and organization structure, environmental
 challenges and needs, and basic employment requirements for this
-position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/director-of-outreach.md
+++ b/_positions/director-of-outreach.md
@@ -4,7 +4,6 @@ permalink: roles-and-teams/positions/director-of-outreach/
 team: communications
 active: true
 ---
-##Role: Director of Outreach
 
 ###Role Summary
 The Director of Outreach creates and guides the strategy for all communications, website, social media, and event messaging to consistently articulate 18F’s mission. The director will work closely with a senior peer group as the communications partner, and with teammates across the organization, helping them effectively tell their stories and share key information with varied audiences. 

--- a/_positions/director-of-technical-architecture.md
+++ b/_positions/director-of-technical-architecture.md
@@ -67,4 +67,4 @@ objectives:
 
 [Read more about management and organization structure, environmental
 challenges and needs, and basic employment requirements for this
-position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/engagement-manager.md
+++ b/_positions/engagement-manager.md
@@ -57,4 +57,4 @@ objectives:
 
 [Read more about management and organization structure, environmental
 challenges and needs, and basic employment requirements for this
-position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/front-end-designer.md
+++ b/_positions/front-end-designer.md
@@ -2,7 +2,7 @@
 title: Front End Designer
 permalink: roles-and-teams/positions/front-end-designer/
 team: design
-active: false
+active: true
 ---
 
 ###Role Summary

--- a/_positions/practical-dev.md
+++ b/_positions/practical-dev.md
@@ -19,4 +19,4 @@ If you feel comfortable finding an existing repository on GitHub, grokking the c
 - Participate in the open source software community by creating open source tools and contributing upstream to existing open source projects.
 - Develop a keen sense of the maturity and extensibility of important open source projects.
 
-[Read more about management and organization structure, environmental challenges and needs, and basic employment requirements for this position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+[Read more about management and organization structure, environmental challenges and needs, and basic employment requirements for this position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/product-lead.md
+++ b/_positions/product-lead.md
@@ -2,7 +2,7 @@
 title: Product Lead
 permalink: roles-and-teams/positions/product-lead/
 team: delivery
-active: false
+active: true
 ---
 
 ###Role Summary

--- a/_positions/resource_manager.md
+++ b/_positions/resource_manager.md
@@ -15,7 +15,7 @@ As the Resource Manager for 18F Consulting, you’ll play the critically importa
 -   We have multiple overlapping and highly fluid client engagements, with new ones starting and old ones finishing all the time. Some run as short as three days; others as long as six months. To complicate matters, resources are not fixed throughout an engagement; different resources are needed at different points in the project.
 
 As you can see, this is a challenging role, but one that is essential to 18F Consulting’s financial and client project success.
-You’ll need to work collaboratively with a number of stakeholders, including members of the 18F Consulting team (particularly [engagement managers](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/engagement-manager/) and [business development staff](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/director-of-biz-dev-and-products/)) and the 18F Talent team, which manages 18F’s hiring operations.
+You’ll need to work collaboratively with a number of stakeholders, including members of the 18F Consulting team (particularly [engagement managers]({{ site.baseurl }}/who-we-are-hiring/positions/engagement-manager/) and [business development staff]({{ site.baseurl }}/who-we-are-hiring/positions/director-of-biz-dev-and-products/)) and the 18F Talent team, which manages 18F’s hiring operations.
 
 ## Key Objectives
 
@@ -29,4 +29,4 @@ Within the first 6-12 months after hiring, you’ll accomplish these objectives:
 
 [Read more about management and organization structure, environmental
 challenges and needs, and basic employment requirements for this
-position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/software-developer.md
+++ b/_positions/software-developer.md
@@ -1,6 +1,6 @@
 ---
 title: Software Developer
-permalink: who-we-are-hiring/positions/software-developer/
+permalink: roles-and-teams/positions/software-developer/
 team: delivery
 active: false
 ---

--- a/_positions/software-developer.md
+++ b/_positions/software-developer.md
@@ -2,7 +2,7 @@
 title: Software Developer
 permalink: roles-and-teams/positions/software-developer/
 team: delivery
-active: false
+active: true
 ---
 
 ###Role Summary

--- a/_positions/technical-architect.md
+++ b/_positions/technical-architect.md
@@ -86,4 +86,4 @@ objectives:
 
 [Read more about management and organization structure, environmental
 challenges and needs, and basic employment requirements for this
-position](https://pages.18f.gov/joining-18f/who-we-are-hiring/positions/18f-consulting/).
+position]({{ site.baseurl }}/who-we-are-hiring/positions/18f-consulting/).

--- a/_positions/visual-designer.md
+++ b/_positions/visual-designer.md
@@ -2,7 +2,7 @@
 title: Visual Designer
 permalink: roles-and-teams/positions/visual-designer/
 team: design
-active: false
+active: true
 ---
 
 ###Role Summary

--- a/index.md
+++ b/index.md
@@ -17,4 +17,4 @@ We will accomplish our mission by:
 * being design-centric, agile, open, and data-driven
 * deploying tools and services early and often
 
-## [Apply to join 18F](/joining-18f/pages/apply.html)
+## [Apply to join 18F]({{ site.baseurl }}/pages/apply.html)

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -318,12 +318,21 @@
 
         <div class="usa-input">
 
-          <label class="ss-q-item-label" for="entry_1108678713">Please select the role to which you&#39;d like to apply:</label>
+          <label class="ss-q-item-label" for="entry_976680464">Please select the role to which you&#39;d like to apply: <span class="required">*</span></label>
           <p>For more information about available roles, please refer to <a href="https://pages.18f.gov/joining-18f/who-we-are-hiring/">this page</a>. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently.</p>
-          <textarea name="entry.1108678713" rows="8" cols="0" class="ss-q-long" id="entry_1108678713" dir="auto" aria-label="Please select the role to which you&#39;d like to apply. For more information about available roles, please refer to https://pages.18f.gov/joining-18f/who-we-are-hiring/. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently. "></textarea>
+          <select name="entry.976680464" id="entry_976680464" aria-label="Please select the role to which you&#39;d like to apply. For more information about available roles, please refer to https://pages.18f.gov/joining-18f/who-we-are-hiring. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently. " aria-required="true" required="">
+
+            <option value=""></option>
+            <option value="Design and Product Strategist">Design and Product Strategist</option>
+            <option value="Director of Outreach">Director of Outreach</option>
+            <option value="Front End Designer">Front End Designer</option>
+            <option value="Product Lead">Product Lead</option>
+            <option value="Site Reliability Engineer">Site Reliability Engineer</option>
+            <option value="Software Developer">Software Developer</option>
+            <option value="Visual Designer">Visual Designer</option>
+          </select>
 
         </div>
-
 
       </fieldset>
 

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -318,9 +318,9 @@
 
         <div class="usa-input">
 
-          <label class="ss-q-item-label" for="entry_1108678713">What role or team at 18F do you believe you&#39;re the best fit for and why?</label>
-          <p>If you need inspiration, check out <a href="https://pages.18f.gov/joining-18f/who-we-are-hiring/">this page</a>. If you don&#39;t see a perfect role there, that&#39;s ok! Just tell us what you think.</p>
-          <textarea name="entry.1108678713" rows="8" cols="0" class="ss-q-long" id="entry_1108678713" dir="auto" aria-label="What role or team at 18F do you believe you&#39;re the best fit for and why? If you need inspiration, check out this page: https://pages.18f.gov/joining-18f/who-we-are-hiring/. If you don&#39;t see a perfect role there, that&#39;s ok! Just tell us what you think. "></textarea>
+          <label class="ss-q-item-label" for="entry_1108678713">Please select the role to which you&#39;d like to apply:</label>
+          <p>For more information about available roles, please refer to <a href="https://pages.18f.gov/joining-18f/who-we-are-hiring/">this page</a>. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently.</p>
+          <textarea name="entry.1108678713" rows="8" cols="0" class="ss-q-long" id="entry_1108678713" dir="auto" aria-label="Please select the role to which you&#39;d like to apply. For more information about available roles, please refer to https://pages.18f.gov/joining-18f/who-we-are-hiring/. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently. "></textarea>
 
         </div>
 

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -334,6 +334,13 @@
 
         </div>
 
+        <div class="usa-input">
+
+          <label class="ss-q-item-label" for="entry_1108678713">Tell us why you&#39;re interested in this role.</label>
+          <textarea name="entry.1108678713" rows="8" cols="0" class="ss-q-long" id="entry_1108678713" dir="auto" aria-label="Tell us why you&#39;re interested in this role. "></textarea>
+
+        </div>
+
       </fieldset>
 
 

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -246,7 +246,7 @@
 
         <div class="usa-input">
 
-          <label class="ss-q-item-label" for="entry_677498968"><div class="ss-q-title">Please indicate your tertiary skillset.</label>
+          <label class="ss-q-item-label" for="entry_677498968">Please indicate your tertiary skillset.</label>
           <select name="entry.677498968" id="entry_677498968" aria-label="Please indicate your tertiary skillset. Optional. Your response here will be used primarily in assigning reviewers for your application. ">
             <option value=""></option>
             <option value="Acquisition, Contracts">Acquisition, Contracts</option> <option value="Business Development">Business Development</option> <option value="Communications, Marketing">Communications, Marketing</option> <option value="Consulting">Consulting</option> <option value="Cybersecurity">Cybersecurity</option> <option value="Design: Visual">Design: Visual</option> <option value="Design: Content">Design: Content</option> <option value="Design: Front End">Design: Front End</option> <option value="Design: UX, Research">Design: UX, Research</option> <option value="Operations, Recruiting">Operations, Recruiting</option> <option value="Product Management">Product Management</option> <option value="Project Management">Project Management</option> <option value="Software Dev: Front End">Software Dev: Front End</option> <option value="Software Dev: Back End">Software Dev: Back End</option> <option value="Software Dev: DevOps, SRE">Software Dev: DevOps, SRE</option>
@@ -256,7 +256,7 @@
 
         <div class="usa-input">
 
-          <label class="ss-q-item-label" for="entry_189037147"><div class="ss-q-title">Other skills you have</label>
+          <label class="ss-q-item-label" for="entry_189037147">Other skills you have</label>
           <textarea name="entry.189037147" rows="8" cols="0" class="ss-q-long" id="entry_189037147" dir="auto" aria-label="Other skills you have  "></textarea>
 
         </div>

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -319,8 +319,8 @@
         <div class="usa-input">
 
           <label class="ss-q-item-label" for="entry_976680464">Please select the role to which you&#39;d like to apply: <span class="required">*</span></label>
-          <p>For more information about available roles, please refer to <a href="https://pages.18f.gov/joining-18f/who-we-are-hiring/">this page</a>. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently.</p>
-          <select name="entry.976680464" id="entry_976680464" aria-label="Please select the role to which you&#39;d like to apply. For more information about available roles, please refer to https://pages.18f.gov/joining-18f/who-we-are-hiring. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently. " aria-required="true" required="">
+          <p>For more information about available roles, please refer to <a href="https://pages.18f.gov/joining-18f/roles-and-teams/">this page</a>. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently.</p>
+          <select name="entry.976680464" id="entry_976680464" aria-label="Please select the role to which you&#39;d like to apply. For more information about available roles, please refer to https://pages.18f.gov/joining-18f/roles-and-teams/. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently. " aria-required="true" required="">
 
             <option value=""></option>
             <option value="Design and Product Strategist">Design and Product Strategist</option>

--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -3,7 +3,7 @@ permalink: /how-to-apply/
 title: How to apply
 ---
 
-##[Apply to join 18F](https://pages.18f.gov/joining-18f/pages/apply.html)
+##[Apply to join 18F]({{ site.baseurl }}/pages/apply.html)
 
 
 If you have any questions, please reach our Talent Team at [join18f@gsa.gov](mailto:join18f@gsa.gov).
@@ -13,7 +13,7 @@ If you have any questions, please reach our Talent Team at [join18f@gsa.gov](mai
 **When you apply, you’ll need to include a current, government-style resume.** Government-style resumes are very different from private-sector resumes. [Here is a guide](http://gogovernment.org/how_to_apply/write_your_federal_resume/create_your_resume.php) and some [example](http://www.fda.gov/downloads/AboutFDA/WorkingatFDA/UCM279014.pdf) [resumes](http://www.jobs.irs.gov/downloads/ResumeTips.pdf). Please overexplain, include dates of each engagement, and include everything and the kitchen sink.
 
 **Later, after you’ve passed through the 18F [interview
-phase](https://pages.18f.gov/joining-18f/interview-process/)**, your point of contact on the 18F Talent Team will ask you for three professional references (names, titles, and email addresses). Once we hear back from them, the GSA HR Team will ask you for additional documents in order to proceed with the hiring process.  
+phase]({{ site.baseurl }}/interview-process/)**, your point of contact on the 18F Talent Team will ask you for three professional references (names, titles, and email addresses). Once we hear back from them, the GSA HR Team will ask you for additional documents in order to proceed with the hiring process.  
 
 It’s not a bad idea to start to pull these together in advance
 because some of them take time to complete. All documents should be

--- a/pages/roles-and-teams.md
+++ b/pages/roles-and-teams.md
@@ -2,60 +2,21 @@
 title: Roles and teams
 permalink: /roles-and-teams/
 ---
-Although everyone is officially hired into the GSA as an Innovation Specialist, our Innovation Specialists fill a wide range of roles on a number of different teams across 18F. Below are a few of the roles that Innovation Specialists may fill at 18F. This is not intended to be a comprehensive list but for those that are interested in joining the team, hopefully something on this list excites you!
+Although everyone is officially hired into the GSA as an Innovation Specialist, our Innovation Specialists fill a wide range of roles across 18F such as software engineers and product leads to UX and visual designers. Below is a list of our current needs but they change frequently, so check back often!
 
 ### Comms Team
-
-**Director of Outreach**
-
-The Director of Outreach drives a comprehensive internal and external communications strategy for 18F. This includes editorial and content on our website, social media, events/conferences, messaging, and general community evangelism.
+[**Director of Outreach**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/director-of-outreach/)
 
 ### Consulting Team
+**Design and Product Strategist** *(Role profile coming soon)*
 
-**Acquisition Specialist**
-
-Acquisition specialists help teams support digital services through procurement efforts, investigate other agencies’ tools and processes to find opportunities to improve results, and work with contracting officers to help procure goods and services for 18F and 18F partner agencies.
-
-**Data Architect**
-
-Data architects on the 18F consulting team help agencies liberate and embrace their data, equip them with profound insights drawn from that data, empowering them to more effectively fulfill their mission.
-
-**Practical Dev**
-
-Practical devs on the 18F consulting team provide broad development expertise and use their consultative know-how to help agencies by conducting workshops and protosketching sessions to build out proofs-of-concept and prototypes.
+The Design and Product Strategist is  at the forefront of human-centered design and culture change within the federal government. As a consultant, you’ll affect how agencies, programs, and individuals perceive and examine problems, dream of solutions, and find innovative ways to make those solutions a successful reality. Depending on the methods you use, you can affect change in a few months (or even days)
 
 ### Delivery Team
+**Site Reliability Engineer** *(Role profile coming soon)*
 
-**DevOps & Site Reliability Engineer**
+Site Reliability Engineers ensure our platforms and infrastructure systems — and the applications on top of them —  are reliable and easy to deploy and maintain. You’ll be involved in designing and implementing systems in a human-centered way, communicating with users, and finding solutions to help people work more smoothly. Along with providing the platform, you seek opportunities and get creative in  architecting solutions.
 
-DevOps engineers work tirelessly to arm developers with the best tools and ensure system uptime and performance, helping to bridge gaps with legacy development or operations teams.
-
-**Product Lead**
-
-18F product leads are responsible for managing the development, delivery, and continuous improvement of products while establishing and managing our relationship with our partners (clients).
-
-**Software Developer (Front-End, Back-End, Full-Stack)**
-
-Using modern, open source web frameworks and tools, our front and back end developers work in small, cross-functional teams to produce functional, scalable web services.
-
-### Design Team
-
-**Content Designer**
-
-Content designers are responsible for creating internal and external content of all varieties and organizing that content for maximum user benefit.
-
-**Front End Designer**
-
-Front end designers work with user experience and visual designers, content creators and development teammates to improve, refine, and develop a well-structured front end workflow and culture.
-
-**User Experience Designer**
-
-User experience designers research, derive insights, generate concepts, communicate those concepts visually, and work with developers and product managers to build them.
-
-**Visual Designer**
-
-Visual designers at 18F craft highly usable and beautiful web-based experiences for the benefit of the public.
 
 ## See also
-
-We also encourage you to consider applying to the [U.S. Digital Service](https://www.whitehouse.gov/digital/united-states-digital-service), which includes opportunities at a broad range of agencies. If you do apply to USDS, please use the referral code "18F" when submitting the application.
+If you're interested in opportunities within the U.S. Digital Service, our sister organization, we encourage you to [apply here](https://www.whitehouse.gov/digital/united-states-digital-service)

--- a/pages/roles-and-teams.md
+++ b/pages/roles-and-teams.md
@@ -12,7 +12,18 @@ Although everyone is officially hired into the GSA as an Innovation Specialist, 
 
 The Design and Product Strategist is at the forefront of human-centered design and culture change within the federal government. As a consultant, you’ll affect how agencies, programs, and individuals perceive and examine problems, dream of solutions, and find innovative ways to make those solutions a successful reality. Depending on the methods you use, you can effect change in a few months (or even days).
 
+### Design Team
+
+[**Front End Designer**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/front-end-designer/)
+
+[**Visual Designer**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/visual-designer/)
+
 ### Delivery Team
+
+[**Software Developer**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/software-developer/)
+
+[**Product Lead**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/product-lead/)
+
 **Site Reliability Engineer** *(Role profile coming soon)*
 
 Site Reliability Engineers ensure our platforms and infrastructure systems &mdash; and the applications on top of them &mdash;  are reliable and easy to deploy and maintain. You’ll be involved in designing and implementing systems in a human-centered way, communicating with users, and finding solutions to help people work more smoothly. Along with providing the platform, you seek opportunities and get creative in  architecting solutions.

--- a/pages/roles-and-teams.md
+++ b/pages/roles-and-teams.md
@@ -26,7 +26,7 @@ The Design and Product Strategist is at the forefront of human-centered design a
 
 **Site Reliability Engineer** *(Role profile coming soon)*
 
-Site Reliability Engineers ensure our platforms and infrastructure systems &mdash; and the applications on top of them &mdash;  are reliable and easy to deploy and maintain. You’ll be involved in designing and implementing systems in a human-centered way, communicating with users, and finding solutions to help people work more smoothly. Along with providing the platform, you seek opportunities and get creative in  architecting solutions.
+As a Site Reliability Engineer, you will ensure our platforms and infrastructure systems &mdash; and the applications on top of them &mdash;  are reliable and easy to deploy and maintain. You’ll be involved in designing and implementing systems in a human-centered way, communicating with users, and finding solutions to help people work more smoothly. Along with providing the platform, you seek opportunities and get creative in  architecting solutions.
 
 
 ## See also

--- a/pages/roles-and-teams.md
+++ b/pages/roles-and-teams.md
@@ -2,21 +2,21 @@
 title: Roles and teams
 permalink: /roles-and-teams/
 ---
-Although everyone is officially hired into the GSA as an Innovation Specialist, our Innovation Specialists fill a wide range of roles across 18F such as software engineers and product leads to UX and visual designers. Below is a list of our current needs but they change frequently, so check back often!
+Although everyone is officially hired into the GSA as an Innovation Specialist, our Innovation Specialists fill a wide range of roles across 18F, from software engineers and product leads to UX and visual designers. Below is a list of our current needs but they change frequently, so check back often!
 
-### Comms Team
+### Communications Team
 [**Director of Outreach**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/director-of-outreach/)
 
 ### Consulting Team
 **Design and Product Strategist** *(Role profile coming soon)*
 
-The Design and Product Strategist is  at the forefront of human-centered design and culture change within the federal government. As a consultant, you’ll affect how agencies, programs, and individuals perceive and examine problems, dream of solutions, and find innovative ways to make those solutions a successful reality. Depending on the methods you use, you can affect change in a few months (or even days)
+The Design and Product Strategist is at the forefront of human-centered design and culture change within the federal government. As a consultant, you’ll affect how agencies, programs, and individuals perceive and examine problems, dream of solutions, and find innovative ways to make those solutions a successful reality. Depending on the methods you use, you can effect change in a few months (or even days).
 
 ### Delivery Team
 **Site Reliability Engineer** *(Role profile coming soon)*
 
-Site Reliability Engineers ensure our platforms and infrastructure systems — and the applications on top of them —  are reliable and easy to deploy and maintain. You’ll be involved in designing and implementing systems in a human-centered way, communicating with users, and finding solutions to help people work more smoothly. Along with providing the platform, you seek opportunities and get creative in  architecting solutions.
+Site Reliability Engineers ensure our platforms and infrastructure systems &mdash; and the applications on top of them &mdash;  are reliable and easy to deploy and maintain. You’ll be involved in designing and implementing systems in a human-centered way, communicating with users, and finding solutions to help people work more smoothly. Along with providing the platform, you seek opportunities and get creative in  architecting solutions.
 
 
 ## See also
-If you're interested in opportunities within the U.S. Digital Service, our sister organization, we encourage you to [apply here](https://www.whitehouse.gov/digital/united-states-digital-service)
+If you're interested in opportunities within the U.S. Digital Service, our sister organization, we encourage you to [apply to USDS directly](https://www.whitehouse.gov/digital/united-states-digital-service).

--- a/pages/roles-and-teams.md
+++ b/pages/roles-and-teams.md
@@ -5,7 +5,7 @@ permalink: /roles-and-teams/
 Although everyone is officially hired into the GSA as an Innovation Specialist, our Innovation Specialists fill a wide range of roles across 18F, from software engineers and product leads to UX and visual designers. Below is a list of our current needs but they change frequently, so check back often!
 
 ### Communications Team
-[**Director of Outreach**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/director-of-outreach/)
+[**Director of Outreach**]({{ site.baseurl }}/roles-and-teams/positions/director-of-outreach/)
 
 ### Consulting Team
 **Design and Product Strategist** *(Role profile coming soon)*
@@ -14,15 +14,15 @@ The Design and Product Strategist is at the forefront of human-centered design a
 
 ### Design Team
 
-[**Front End Designer**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/front-end-designer/)
+[**Front End Designer**]({{ site.baseurl }}/roles-and-teams/positions/front-end-designer/)
 
-[**Visual Designer**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/visual-designer/)
+[**Visual Designer**]({{ site.baseurl }}/roles-and-teams/positions/visual-designer/)
 
 ### Delivery Team
 
-[**Software Developer**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/software-developer/)
+[**Software Developer**]({{ site.baseurl }}/roles-and-teams/positions/software-developer/)
 
-[**Product Lead**](https://pages.18f.gov/joining-18f/roles-and-teams/positions/product-lead/)
+[**Product Lead**]({{ site.baseurl }}/roles-and-teams/positions/product-lead/)
 
 **Site Reliability Engineer** *(Role profile coming soon)*
 


### PR DESCRIPTION
This is no longer a work in progress and can be reviewed / discussed for merge.

This resolves #185.
This resolves #157.
## Goal

The goal of this PR is to move URLs to relative links where applicable, so that the links will function in relative environments such as another host or when built via Jekyll locally.
## Overall changes to allow for relative URLs:
- **Use the site.baseurl variable**: All markdown files were updated to use `{{ site.baseurl }}` as the first path of their path. This should be the original combination of host. 
  - Note: This can be set in the `_config.yml` file, though in our case we're good to leave it as the default (I believe -- see "Potential Issues" below)
## Potential Issues
- This does not affect `.html` files, which will need to have the full URL still for the time being. I believe there's a way around this, but it should be addressed as a separate PR.
- This PR makes the assumption that Github knows the baseurl includes `/joining-18f`, which I believe is correct. However, if I'm incorrect, this means that we'd have to add the `baseurl: "/joining-18f"` to the `_config.yml` file. It would be a quick change, but you may want to consider this before pushing as it could result in some minor downtime if I'm wrong.
## Work List

After a quick review, it looks like the following pages contain links that could be made relative:
- [x] index.md
- [x] how-to-apply.md
- [x] ~~readme.md~~ 
  - (leaving static URL here for cloning, etc. since it's meant to point to the official site).
- [x] acquisition-specialist.md
- [x] data-architect.md
- [x] design-and-product-strategist.md
- [x] director-of-biz-dev-and-products.md 
- [x] director-of-technical-architecture.md 
- [x] engagement-manager.md 
- [x] practical-dev.md
- [x] resource_manager.md
- [x] technical-architect.md
