### PR TITLE
Remove unclosed divs

### DIFF
--- a/pages/apply.html
+++ b/pages/apply.html
@@ -246,7 +246,7 @@
 
         <div class="usa-input">
 
-          <label class="ss-q-item-label" for="entry_677498968"><div class="ss-q-title">Please indicate your tertiary skillset.</label>
+          <label class="ss-q-item-label" for="entry_677498968">Please indicate your tertiary skillset.</label>
           <select name="entry.677498968" id="entry_677498968" aria-label="Please indicate your tertiary skillset. Optional. Your response here will be used primarily in assigning reviewers for your application. ">
             <option value=""></option>
             <option value="Acquisition, Contracts">Acquisition, Contracts</option> <option value="Business Development">Business Development</option> <option value="Communications, Marketing">Communications, Marketing</option> <option value="Consulting">Consulting</option> <option value="Cybersecurity">Cybersecurity</option> <option value="Design: Visual">Design: Visual</option> <option value="Design: Content">Design: Content</option> <option value="Design: Front End">Design: Front End</option> <option value="Design: UX, Research">Design: UX, Research</option> <option value="Operations, Recruiting">Operations, Recruiting</option> <option value="Product Management">Product Management</option> <option value="Project Management">Project Management</option> <option value="Software Dev: Front End">Software Dev: Front End</option> <option value="Software Dev: Back End">Software Dev: Back End</option> <option value="Software Dev: DevOps, SRE">Software Dev: DevOps, SRE</option>
@@ -256,7 +256,7 @@
 
         <div class="usa-input">
 
-          <label class="ss-q-item-label" for="entry_189037147"><div class="ss-q-title">Other skills you have</label>
+          <label class="ss-q-item-label" for="entry_189037147">Other skills you have</label>
           <textarea name="entry.189037147" rows="8" cols="0" class="ss-q-long" id="entry_189037147" dir="auto" aria-label="Other skills you have  "></textarea>
 
         </div>


### PR DESCRIPTION
Minor detail: The selected option for 'tertiary skillset' had a different font weight than the other two skillset fields. Looks like it was because of an unclosed div. Removed it, and one other.

![image](https://cloud.githubusercontent.com/assets/110948/11863252/789d3aa8-a4a3-11e5-9ea6-d399985a8624.png)
