### PR TITLE
Give the 'available roles' link meaningful text

### DIFF
--- a/pages/apply.html
+++ b/pages/apply.html
@@ -319,8 +319,8 @@
         <div class="usa-input">
 
           <label class="ss-q-item-label" for="entry_976680464">Please select the role to which you&#39;d like to apply: <span class="required">*</span></label>
-          <p>For more information about available roles, please refer to <a href="https://pages.18f.gov/joining-18f/roles-and-teams/">this page</a>. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently.</p>
-          <select name="entry.976680464" id="entry_976680464" aria-label="Please select the role to which you&#39;d like to apply. For more information about available roles, please refer to https://pages.18f.gov/joining-18f/roles-and-teams/. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently. " aria-required="true" required="">
+          <p>For more information, please review the <a href="https://pages.18f.gov/joining-18f/roles-and-teams/">available roles</a>. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently.</p>
+          <select name="entry.976680464" id="entry_976680464" aria-label="Please select the role to which you&#39;d like to apply. For more information, please review the available roles at https://pages.18f.gov/joining-18f/roles-and-teams/. If you don&#39;t see a role that is a good fit for you, please check back soon as our needs change frequently. " aria-required="true" required="">
 
             <option value=""></option>
             <option value="Design and Product Strategist">Design and Product Strategist</option>


### PR DESCRIPTION
As noted in #194, 'this page' isn't ideal for screen readers (or for content strategy in general).
