### PR TITLE
Update Apply Link on landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,4 +17,4 @@ We will accomplish our mission by:
 * being design-centric, agile, open, and data-driven
 * deploying tools and services early and often
 
-## [Apply to join 18F](/joining-18f/pages/apply.html)
+## [Apply to join 18F]({{ site.baseurl }}/roles-and-teams/)

--- a/index.md
+++ b/index.md
@@ -17,4 +17,4 @@ We will accomplish our mission by:
 * being design-centric, agile, open, and data-driven
 * deploying tools and services early and often
 
-## [Apply to join 18F]({{ site.baseurl }}/roles-and-teams/)
+## [Review current roles and apply to join 18F]({{ site.baseurl }}/roles-and-teams/)


### PR DESCRIPTION
Update the apply link to direct to the roles and teams page where links to the applications for each specific role are housed.

To #189
