### PR TITLE
Adding apply link to the Outreach position description

### DIFF
--- a/_positions/director-of-outreach.md
+++ b/_positions/director-of-outreach.md
@@ -29,5 +29,5 @@ You’re a broad and strategic thinker who can see the interconnectivity between
 - Define team and individual performance metrics and expected business results through OKRs and regular calibration of team goals with individual goals.
 
 
-## [Apply to join 18F](/joining-18f/pages/apply.html)
+##[Apply to join 18F]({{ site.baseurl }}/pages/apply.html)
 

--- a/_positions/director-of-outreach.md
+++ b/_positions/director-of-outreach.md
@@ -29,5 +29,5 @@ You’re a broad and strategic thinker who can see the interconnectivity between
 - Define team and individual performance metrics and expected business results through OKRs and regular calibration of team goals with individual goals.
 
 
-##[Apply to join 18F](https://jobs.lever.co/18f/1e419ac8-737d-4edb-b5ab-f186775246f1/apply)
+##[Apply to the Director of Outreach role](https://jobs.lever.co/18f/1e419ac8-737d-4edb-b5ab-f186775246f1/apply)
 

--- a/_positions/director-of-outreach.md
+++ b/_positions/director-of-outreach.md
@@ -29,3 +29,5 @@ You’re a broad and strategic thinker who can see the interconnectivity between
 - Define team and individual performance metrics and expected business results through OKRs and regular calibration of team goals with individual goals.
 
 
+## [Apply to join 18F](/joining-18f/pages/apply.html)
+

--- a/_positions/director-of-outreach.md
+++ b/_positions/director-of-outreach.md
@@ -29,5 +29,5 @@ You’re a broad and strategic thinker who can see the interconnectivity between
 - Define team and individual performance metrics and expected business results through OKRs and regular calibration of team goals with individual goals.
 
 
-##[Apply to join 18F]({{ site.baseurl }}/pages/apply.html)
+##[Apply to join 18F](https://jobs.lever.co/18f/1e419ac8-737d-4edb-b5ab-f186775246f1/apply)
 


### PR DESCRIPTION
This link will route to the Lever application for the Director of Outreach. This position will be the pilot to test before making the full cut over.

Adding the link to the application to each specific role to prepare for the cut over to the Lever hosted application.

To #189
