### PR TITLE
Add apply link on the strategist role

### DIFF
--- a/_positions/design-and-product-strategist.md
+++ b/_positions/design-and-product-strategist.md
@@ -48,4 +48,4 @@ Your projects will come from various federal agencies. Some will improve service
 - Facilitate culture change inside the government contracting industry by educating stakeholders and contracting officers about design and agile processes.
 - Review proposals from vendors and assess them for design, research, usability testing, and product process acumen.
 
-##[Apply to join 18F](https://jobs.lever.co/18f/73bfd32b-ee89-4597-848f-745e58d11efd/apply)
+##[Apply to the Design and Product Strategist role](https://jobs.lever.co/18f/73bfd32b-ee89-4597-848f-745e58d11efd/apply)

--- a/_positions/design-and-product-strategist.md
+++ b/_positions/design-and-product-strategist.md
@@ -48,3 +48,4 @@ Your projects will come from various federal agencies. Some will improve service
 - Facilitate culture change inside the government contracting industry by educating stakeholders and contracting officers about design and agile processes.
 - Review proposals from vendors and assess them for design, research, usability testing, and product process acumen.
 
+## [Apply to join 18F](/joining-18f/pages/apply.html)

--- a/_positions/design-and-product-strategist.md
+++ b/_positions/design-and-product-strategist.md
@@ -48,4 +48,4 @@ Your projects will come from various federal agencies. Some will improve service
 - Facilitate culture change inside the government contracting industry by educating stakeholders and contracting officers about design and agile processes.
 - Review proposals from vendors and assess them for design, research, usability testing, and product process acumen.
 
-## [Apply to join 18F](/joining-18f/pages/apply.html)
+##[Apply to join 18F]({{ site.baseurl }}/pages/apply.html)

--- a/_positions/design-and-product-strategist.md
+++ b/_positions/design-and-product-strategist.md
@@ -48,4 +48,4 @@ Your projects will come from various federal agencies. Some will improve service
 - Facilitate culture change inside the government contracting industry by educating stakeholders and contracting officers about design and agile processes.
 - Review proposals from vendors and assess them for design, research, usability testing, and product process acumen.
 
-##[Apply to join 18F]({{ site.baseurl }}/pages/apply.html)
+##[Apply to join 18F](https://jobs.lever.co/18f/73bfd32b-ee89-4597-848f-745e58d11efd/apply)


### PR DESCRIPTION
Adding the link to the application to each specific role to prepare for the cut over to the Lever hosted application.

To #189
