### PR TITLE
Adding apply link to software dev position

### DIFF
--- a/_positions/software-developer.md
+++ b/_positions/software-developer.md
@@ -32,4 +32,4 @@ Using modern, open source web frameworks and tools, our developers (front end, b
 - Demonstrate resilience in the face of bureaucracy: When faced with a hurdle, determine the root cause and address that in addition to the hurdle itself.
 - Push the boundaries of what is possible within government while maintaining an understanding of the complexities of the organization; push back against the things that can be pushed back against and take a longer view for the things that can't.
 
-##[Apply to join 18F]({{ site.baseurl }}/pages/apply.html)
+##[Apply to the Software Developer role](https://jobs.lever.co/18f/40d0f4ee-be99-47be-be03-29b2095e51f6/apply)

--- a/_positions/software-developer.md
+++ b/_positions/software-developer.md
@@ -31,3 +31,5 @@ Using modern, open source web frameworks and tools, our developers (front end, b
 - Participate in or lead (as necessary) an open dialogue with representatives from our partner agencies in implementing modern development standards, including transparency, user-centered design, and agile methodologies; understand and communicate the "why" of these standards, not just the "what."
 - Demonstrate resilience in the face of bureaucracy: When faced with a hurdle, determine the root cause and address that in addition to the hurdle itself.
 - Push the boundaries of what is possible within government while maintaining an understanding of the complexities of the organization; push back against the things that can be pushed back against and take a longer view for the things that can't.
+
+##[Apply to join 18F]({{ site.baseurl }}/pages/apply.html)


### PR DESCRIPTION
Adding the link to the application to each specific role to prepare for the cut over to the Lever hosted application.

To #189
