### PR TITLE
fix broken pay grade description links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,8 @@ collections:
   interviews:
     permalink: /interviews/:title/
     output: true
+  positions:
+    output: true
 
 google_analytics_ua: UA-48605964-19
 


### PR DESCRIPTION
Prior to this commit, the links for the various pay grades were broken
because the pages for the postitions were not generated. This commit
adds positions to the configuration for generation and output.
