### PR TITLE
Add application link

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -19,4 +19,4 @@ We will accomplish our mission by:
 
 We know, there is a lot of information on this site, which can be intimidating. Federal hiring processes are more complex than most other places, so we want to make sure you have all the information you need. We're happy you're interested in joining the team!
 
-## [Review current roles and apply to join 18F]({{ site.baseurl }}/roles-and-teams/)
+## [Review open positions and apply to join 18F]({{ site.baseurl }}/roles-and-teams/)

--- a/pages/who-we-are-hiring.md
+++ b/pages/who-we-are-hiring.md
@@ -13,3 +13,5 @@ We’re building a team that looks like the United States, and we don't discrimi
 ## Where we are hiring
 
 Everywhere in the United States! Most of our team is distributed across the country in places like Chicago, New York, Raleigh, Tucson, Austin, Dayton, Philadelphia, San Diego, Seattle, and Portland. [Read more about how our work culture supports distributed teams.](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/) In some cases we'll ask you to work out of our offices in San Francisco, Chicago, or D.C. Unfortunately, we can't provide relocation assistance.
+
+## [Review open positions and apply to join 18F]({{ site.baseurl }}/roles-and-teams/)


### PR DESCRIPTION
This PR does two things:
- Add an application link to the bottom of the "Who we are hiring" page (per #239)
- Change the phrasing of that link, in both locations, from `current roles` to `open positions` (inspired by #238)

Technical note: I'd prefer to refactor this link as an include for DRY purposes, but that appears to be less trivial than I'd supposed because of the way Jekyll renders markdown includes, so let's handle that in a separate PR. markdownify, I've got my eye on you.
