### PR TITLE
added css for job listing on mobile so it displays as a single col

### DIFF
--- a/assets/css/leverpostings.css
+++ b/assets/css/leverpostings.css
@@ -19,6 +19,12 @@ p {
   width: 50%;
   padding: 40px 30px;
 }
+@media screen and (max-width: 45em) {
+  .job {
+      width: 100%;
+      padding: 20px 0px;
+    }
+}
 h1 {
   font-size: 48px;
   color: #454545;


### PR DESCRIPTION
<img width="849" alt="screen shot 2016-02-11 at 20 27 29" src="https://cloud.githubusercontent.com/assets/4334015/12989565/efdabe02-d0fd-11e5-8538-b79908ed5540.png">

I used 45em as a break point - this is the same break point as CSS on the aside!
