### PR TITLE
Reimplement #249, fixing redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,8 +32,8 @@ navigation:
 - text: Who we are hiring
   url: who-we-are-hiring/
   internal: true
-- text: Roles and teams
-  url: roles-and-teams/
+- text: Open positions
+  url: open-positions/
   internal: true
 - text: How to apply
   url: how-to-apply/

--- a/pages/open-positions.md
+++ b/pages/open-positions.md
@@ -1,6 +1,7 @@
 ---
-title: Roles and teams
-permalink: /roles-and-teams/
+title: Open positions
+permalink: /open-positions/
+redirect_from: /roles-and-teams/
 styles: assets/css/leverpostings.css
 scripts: assets/js/leverpostings.js
 ---


### PR DESCRIPTION
**Technical notes:**
The only difference between this and #249 is a trailing slash in the `redirect_from` value.

**Testing instructions:**
Please review on staging:
1. Go to https://pages-staging.18f.gov/joining-18f/.
2. Confirm that you see an 'Open positions' nav item.
3. Click the 'Open positions' nav item.
4. Confirm that it takes you to https://pages-staging.18f.gov/joining-18f/open-positions/.
5. Enter the URL https://pages-staging.18f.gov/joining-18f/roles-and-teams/.
6. Confirm that that also takes you to https://pages-staging.18f.gov/joining-18f/open-positions/.

Fixes #238 and #251.
