### PR TITLE
Minor content change

### DIFF
--- a/pages/open-positions.md
+++ b/pages/open-positions.md
@@ -10,6 +10,7 @@ scripts: assets/js/leverpostings.js
 We have taken down our open positions for a short application intake hiatus. During this time, we’ll be evolving how 18F plans for open roles. We estimate that we’ll post new open positions in the beginning of June and suggest that you check back here at that time.
 
 If you would like to recieve a notification when we resume application intake, please send an email to join18F@gsa.gov includin your name and preferred contact email.
+
 ---
 
 {% include leverpostings.html %}

--- a/pages/open-positions.md
+++ b/pages/open-positions.md
@@ -9,7 +9,7 @@ scripts: assets/js/leverpostings.js
 ###Important Announcement###
 We have taken down our open positions for a short application intake hiatus. During this time, we’ll be evolving how 18F plans for open roles. We estimate that we’ll post new open positions in the beginning of June and suggest that you check back here at that time.
 
-If you would like to recieve a notification when we resume application intake, please send an email to join18F@gsa.gov includin your name and preferred contact email.
+If you would like to recieve a notification when we resume application intake, please send an email to join18F@gsa.gov including your name and preferred contact email address.
 
 ---
 

--- a/pages/open-positions.md
+++ b/pages/open-positions.md
@@ -7,16 +7,10 @@ scripts: assets/js/leverpostings.js
 ---
 
 ###Important Announcement###
-On May 1, we’ll be taking down our open positions for a short application intake hiatus. During that time, we’ll be evolving how 18F plans for open roles. We estimate that we’ll post new open positions in the beginning of June and suggest that you check back here at that time.
+We have taken down our open positions for a short application intake hiatus. During this time, we’ll be evolving how 18F plans for open roles. We estimate that we’ll post new open positions in the beginning of June and suggest that you check back here at that time.
 
-If you are thinking of applying, we encourage you to submit an application as soon as possible, as we will consider all applications submitted **on or before May 1**.
-
-During our short intake hiatus, we would still love to hear from you. If you’re interested in joining our team or want to know more about what it’s like to be part of 18F, please send us a note at join18F@gsa.gov and the talent team will respond. 
-
+If you would like to recieve a notification when we resume application intake, please send an email to join18F@gsa.gov includin your name and preferred contact email.
 ---
-Our Innovation Specialists fill a wide range of roles across 18F, from software engineers and product leads to UX and visual designers. **Most roles can be done remotely or from any of our offices.** The application form will specify any location restrictions.
-
-Below is a list of our current needs. They change frequently, so check back often!
 
 {% include leverpostings.html %}
 


### PR DESCRIPTION
Removing the content that refers to the intake occurring in the future. 

To reduce confusion, also removed the "Our Innovation Specialists fill a wide range of roles across 18F, from software engineers and product leads to UX and visual designers. **Most roles can be done remotely or from any of our offices.** The application form will specify any location restrictions.

Below is a list of our current needs. They change frequently, so check back often!
"
