### PR TITLE
Replaced 404'd OPM link about "Category Rating"

### DIFF
--- a/pages/interview-process.md
+++ b/pages/interview-process.md
@@ -9,7 +9,7 @@ Applications are collected and grouped in two-week intervals. All applications c
 **Note:** Once an application period ends, no additions or modifications can be made to your application. However, there is no limit to the number of times you can apply.
 
 ## Application review (Qualification)
-The first step of the process will be a review of the information that you have submitted as part of your application. Applications are evaluated using the practices of the qualification processes called [Category Rating](https://www.opm.gov/policy-data-oversight/human-capital-management/hiring-reform/reference/categoryratingpolicytemplate.pdf). Your application is evaluated against the competencies listed below and placed in one of the following categories: Superior Qualified, Best Qualified, Well Qualified, Qualified, or Not Qualified. We also apply [Veterans' Preference](http://www.fedshirevets.gov/job/vetpref/index.aspx).
+The first step of the process will be a review of the information that you have submitted as part of your application. Applications are evaluated using the practices of the qualification processes called [Category Rating](https://www.opm.gov/policy-data-oversight/hiring-information/competitive-hiring/#url=Category-Rating). Your application is evaluated against the competencies listed below and placed in one of the following categories: Superior Qualified, Best Qualified, Well Qualified, Qualified, or Not Qualified. We also apply [Veterans' Preference](http://www.fedshirevets.gov/job/vetpref/index.aspx).
 
 Once all applications within the two-week cohort have been evaluated, they're given to the selection panel, which will review and identify the applicants that they wish to interview.
 

--- a/pages/interview-process.md
+++ b/pages/interview-process.md
@@ -9,7 +9,7 @@ Applications are collected and grouped in two-week intervals. All applications c
 **Note:** Once an application period ends, no additions or modifications can be made to your application. However, there is no limit to the number of times you can apply.
 
 ## Application review (Qualification)
-The first step of the process will be a review of the information that you have submitted as part of your application. Applications are evaluated using the practices of the qualification processes called [Category Rating](https://www.opm.gov/policy-data-oversight/hiring-authorities/competitive-hiring/#url=Category-Rating). Your application is evaluated against the competencies listed below and placed in one of the following categories: Superior Qualified, Best Qualified, Well Qualified, Qualified, or Not Qualified. We also apply [Veterans' Preference](http://www.fedshirevets.gov/job/vetpref/index.aspx).
+The first step of the process will be a review of the information that you have submitted as part of your application. Applications are evaluated using the practices of the qualification processes called [Category Rating](https://www.opm.gov/policy-data-oversight/human-capital-management/hiring-reform/reference/categoryratingpolicytemplate.pdf). Your application is evaluated against the competencies listed below and placed in one of the following categories: Superior Qualified, Best Qualified, Well Qualified, Qualified, or Not Qualified. We also apply [Veterans' Preference](http://www.fedshirevets.gov/job/vetpref/index.aspx).
 
 Once all applications within the two-week cohort have been evaluated, they're given to the selection panel, which will review and identify the applicants that they wish to interview.
 


### PR DESCRIPTION
The current link intended to explain "Category Rating" on the OPM website led to a 404 error. I replaced it with what I believe is the new link for the page the original link was linking to.
