### PR TITLE
Switched BENEFEDS link to plan search URL

### DIFF
--- a/pages/benefits.md
+++ b/pages/benefits.md
@@ -7,7 +7,7 @@ title: Benefits
 
 Explore health care plans offered: [FEHB](https://www.opm.gov/healthcare-insurance/healthcare/plan-information/plans/).
 
-Explore dental and vision plans at [BENEFEDS](https://www.benefeds.com); just throw in your zip code.
+Explore dental and vision plans at [BENEFEDS](https://www.benefeds.com/Portal/PlanSearch?submit=planSearch); just throw in your zip code.
 
 Most new employees are automatically covered by basic life insurance, with the option to elect into additional coverage. Find out more [here](http://www.opm.gov/healthcare-insurance/life-insurance/).
 


### PR DESCRIPTION
The current link under BENEFEDS leads to the homepage, but the corresponding text says "just throw in your zip code." I changed the link to lead to the actual "Plan Search" page that allows someone to put in their zip code and search the available plans.
