### PR TITLE
Added 3 infosec position descriptions to our join page

### DIFF
--- a/_positions/application-security-engineer.md
+++ b/_positions/application-security-engineer.md
@@ -1,0 +1,45 @@
+---
+title: Application Security Engineer
+permalink: infosec/application-security-engineer/
+team: 18F
+active: true
+---
+
+18F is looking for talented security engineers to join our team and help us build secure applications. This is a unique opportunity to help re-define how the government builds secure software. You’ll be a key contributor in helping to secure the tools and technology that the American people use to interact with the government. [18F is an open source team](https://18f.gsa.gov/2014/07/29/18f-an-open-source-team/), so most of what you work on will be open source.
+
+**This role is perfect for you if you care deeply about shipping secure code.** You should be excited to spread that knowledge throughout 18F’s engineering disciplines — and beyond.
+
+[Apply for this job](https://jobs.lever.co/18f/52e26cd1-0750-4481-af7f-8bb39e7dcde0)
+
+### You will:
+
+* Collaborate with fellow members of 18F Engineering to develop secure development best practices.
+* Join product teams to provide security expertise on sensitive or risky projects.
+* Perform security assessments on web applications, software services, and data systems.
+* Develop tools, processes, and practices that help automate the practice of developing secure software.
+* Create and operate secure development programs for our engineering teams and partners.
+
+### Requirements:
+
+* Broad exposure to a variety of security sub-specialties.
+* A background in software engineering, with experience in web application architecture.
+* Strong written and verbal communication skills, especially the ability to communicate with grace and empathy when delivering feedback to other engineers.
+* Proficiency with at least one programming language, such as Ruby, Python, Node, Go, etc.
+* A deep understanding of secure coding practices and web application security, and the ability to teach that understanding to other engineers.
+
+### Strong candidates will have experience with, or a desire to learn, some of the following:
+
+* Penetration testing and remediating issues discovered via penetration tests.
+* Threat modeling and/or other threat analysis techniques.
+* Designing secure network architectures
+* Strong understanding of secure communications standards and practices
+* Identity and access management principles.
+* Understanding of cryptography principles and encryption technologies.
+* Securing IaaS, PaaS, and SaaS applications.
+
+Before applying, go to [join.18f.gov](https://join.18f.gov/) to read important information related to government pay grades, the application process, and how our interviews work. We recommend keeping [join.18f.gov](https://join.18f.gov/) open for ease of reference while you answer application questions.
+
+This position is set at a GS-15 level ([learn more about senior level pay grades here](https://pages.18f.gov/joining-18f/pay-grades/)).
+
+[Apply for this job](https://jobs.lever.co/18f/52e26cd1-0750-4481-af7f-8bb39e7dcde0)
+

--- a/_positions/penetration-tester.md
+++ b/_positions/penetration-tester.md
@@ -1,0 +1,50 @@
+---
+title: Penetration Tester
+permalink: infosec/penetration-tester/
+team: 18F
+active: true
+---
+
+18F is looking for talented security engineers to join our team and help us build secure applications. This is a unique opportunity to help re-define how the government builds secure software. You’ll be a key contributor in helping to secure the tools and technology that the American people use to interact with the government. [18F is an open source team](https://18f.gsa.gov/2014/07/29/18f-an-open-source-team/), so most of what you work on will be open source.
+
+**This role is perfect for you if you love “breaking” systems to make them better.** You should be excited to get to find exploits in our software — and then work with us to fix them!
+
+[Apply for this job](https://jobs.lever.co/18f/a546d4f2-3db5-4a63-8af6-05fc9f0ec522)
+
+### You will:
+
+* Perform application and infrastructure penetration tests against our (and our partners’) software and infrastructure.
+* Summarize and explain your findings to engineering and product teams, and work closely with teams to remediate those issues.
+* Review and define requirements for information security solutions.
+* Perform security reviews of application designs, source code and deployments as required, covering all types of applications (web application, web services, mobile applications, thick client applications, SaaS)
+* Participate in security assessments of our (and our partners’) networks, systems and applications.
+* Work on improvements for provided security services, including the continuous enhancement of existing methodology material and supporting assets.
+
+### Requirements:
+
+* Broad exposure to a variety of security sub-specialties.
+* Experience performing penetration tests against web applications and infrastructure.
+* Strong written and verbal communication skills, especially the ability to communicate with grace and empathy when delivering feedback to other engineers.
+* A deep understanding of web application security, and the ability to teach that understanding to other engineers.
+* Good understanding of network protocols, design and operations.
+* Vulnerability and threat management experience.
+* Willingness to travel as this position may require on-site work at our partner agencies.
+
+### Strong candidates will have experience with, or a desire to learn, some of the following:
+
+* Application development with at least least one programming language, such as Ruby, Python, Node, Go, etc.
+* Good understanding of the components of a secure SDLC, and particular its application in an agile environment.
+* Vulnerability analysis and application reversing.
+* Monitoring and assessing security advisories.
+* Understanding of cryptography principles and encryption technologies.
+* Threat modeling and/or other threat analysis techniques.
+* Designing secure network architectures.
+* Identity and access management principles.
+* Securing IaaS, PaaS, and SaaS applications.
+
+Before applying, go to [join.18f.gov](https://join.18f.gov/) to read important information related to government pay grades, the application process, and how our interviews work. We recommend keeping [join.18f.gov](https://join.18f.gov/) open for ease of reference while you answer application questions.
+
+This position is set at a GS-15 level ([learn more about senior level pay grades here](https://pages.18f.gov/joining-18f/pay-grades/)).
+
+[Apply for this job](https://jobs.lever.co/18f/a546d4f2-3db5-4a63-8af6-05fc9f0ec522)
+

--- a/_positions/security-operations-engineer.md
+++ b/_positions/security-operations-engineer.md
@@ -15,10 +15,10 @@ active: true
 
 ### You will:
 
-° Develop and operate process and tools around cloud-based solutions, particularly AWS and Cloud Foundry.
-° Detect, respond to and lead the remediation for security events.
-° Develop and implement tools and/or procedures for detecting and remediating malicious activity.
-° Work in partnership with teams at 18F and/or other agencies to improve their security posture and detection/response capabilities.
+* Develop and operate process and tools around cloud-based solutions, particularly AWS and Cloud Foundry.
+* Detect, respond to and lead the remediation for security events.
+* Develop and implement tools and/or procedures for detecting and remediating malicious activity.
+* Work in partnership with teams at 18F and/or other agencies to improve their security posture and detection/response capabilities.
 * Collaborate with 18F’s infrastructure and fellow engineering staff to develop operational security best practices.
 
 ### Requirements:

--- a/_positions/security-operations-engineer.md
+++ b/_positions/security-operations-engineer.md
@@ -1,0 +1,48 @@
+---
+title: Security Operations Engineer
+permalink: infosec/security-operations-engineer/
+team: 18F
+active: true
+---
+
+# Security Operations Engineer
+
+18F is looking for talented security engineers to join our team and help us build secure applications. This is a unique opportunity to help re-define how the government builds secure software. You’ll be a key contributor in helping to secure the tools and technology that the American people use to interact with the government. [18F is an open source team](https://18f.gsa.gov/2014/07/29/18f-an-open-source-team/), so most of what you work on will be open source.
+
+**This role is perfect for you if you love building and improving infrastructure systemically.** You should be excited to build automated systems that address security issues before they happen.
+
+[Apply for this job](https://jobs.lever.co/18f/8774d280-438e-487b-bacc-42056eb28d42)
+
+### You will:
+
+° Develop and operate process and tools around cloud-based solutions, particularly AWS and Cloud Foundry.
+° Detect, respond to and lead the remediation for security events.
+° Develop and implement tools and/or procedures for detecting and remediating malicious activity.
+° Work in partnership with teams at 18F and/or other agencies to improve their security posture and detection/response capabilities.
+* Collaborate with 18F’s infrastructure and fellow engineering staff to develop operational security best practices.
+
+### Requirements:
+
+* Broad exposure to a variety of security sub-specialties.
+* An understanding of Amazon Web Services (VPC, EC2, S3, IAM, etc).
+* Strong written and verbal communication skills, especially the ability to communicate with grace and empathy when delivering feedback to other engineers.
+* Experience responding to security events as part of an engineering/operations team.
+* Forensic experience with at least one major operating system (preferably Linux or OS X)
+* Proficiency with at least one programming language, such as Ruby, Python, Node, Go, etc.
+* Experience using and administering Linux-based operating systems.
+* Designing monitoring solutions for secure network architectures.
+* Identity and access management principles.
+
+### Strong candidates will have experience with, or a desire to learn, some of the following:
+
+* Penetration testing and remediating issues discovered via penetration tests.
+* Threat modeling and/or other threat analysis techniques.
+* Understanding of cryptography principles and encryption technologies.
+* The Cloud Foundry ecosystem.
+
+Before applying, go to [join.18f.gov](https://join.18f.gov/) to read important information related to government pay grades, the application process, and how our interviews work. We recommend keeping [join.18f.gov](https://join.18f.gov/) open for ease of reference while you answer application questions.
+
+This position is set at a GS-15 level ([learn more about senior level pay grades here](https://pages.18f.gov/joining-18f/pay-grades/)).
+
+[Apply for this job](https://jobs.lever.co/18f/8774d280-438e-487b-bacc-42056eb28d42)
+


### PR DESCRIPTION
This gets 3 landing pages up for each of 3 infosec positions, each of which is backed by [this positoin on USAJobs](https://www.usajobs.gov/GetJob/ViewDetails/442522300/). However, it's a direct hire position and people are free to apply directly, through these landing pages.

This position is open now, and we're tentatively planning to pause things at the end of the month, so we'd like them posted now even while other changes to the pipeline are happening.
