### PR TITLE
Remove 404 link to example resume

### DIFF
--- a/pages/how-to-apply.md
+++ b/pages/how-to-apply.md
@@ -9,10 +9,10 @@ If you have any questions, please reach our Talent Team at [join18f@gsa.gov](mai
 
 ## Documents required for the hiring process
 
-**When you apply, you’ll need to include a current, government-style resume.** Government-style resumes are very different from private-sector resumes. [Here is a guide](http://gogovernment.org/how_to_apply/write_your_federal_resume/create_your_resume.php) and some [example](http://www.fda.gov/downloads/AboutFDA/WorkingatFDA/UCM279014.pdf) [resumes](http://www.jobs.irs.gov/downloads/ResumeTips.pdf). Please overexplain, include dates of each engagement, and include everything and the kitchen sink.
+**When you apply, you’ll need to include a current, government-style resume.** Government-style resumes are very different from private-sector resumes. [Here is a guide](http://gogovernment.org/how_to_apply/write_your_federal_resume/create_your_resume.php) and an [example resume](http://www.fda.gov/downloads/AboutFDA/WorkingatFDA/UCM279014.pdf). Please overexplain, include dates of each engagement, and include everything and the kitchen sink.
 
 **Later, after you’ve passed through the 18F [interview
-phase]({{ site.baseurl }}/interview-process/)**, your point of contact on the 18F Talent Team will ask you for three professional references (names, titles, and email addresses). Once we hear back from them, the GSA HR Team will ask you for additional documents in order to proceed with the hiring process.  
+phase]({{ site.baseurl }}/interview-process/)**, your point of contact on the 18F Talent Team will ask you for three professional references (names, titles, and email addresses). Once we hear back from them, the GSA HR Team will ask you for additional documents in order to proceed with the hiring process.
 
 It’s not a bad idea to start to pull these together in advance
 because some of them take time to complete. All documents should be
@@ -38,6 +38,6 @@ The GSA hiring process includes a tentative offer followed by an official offer.
 
 All government positions require some kind of background check. Most positions at 18F require a public trust position clearance, which is more thorough than most private-sector background checks but not as intensive as a higher security clearance. The clearance process adds some time and forms to the hiring process, but GSA's human resources team will guide you through it.
 
-The questionnaire you'll need to fill out is called [e-QIP](https://www.opm.gov/investigations/e-qip-application/). The questions cover seven years worth of employment and location history, among other things. It may take substantial time to collect contact information for previous employers, as well as old addresses. The e-QIP questionnaire is basically a web version of the [SF-85p](https://www.opm.gov/forms/pdf_fill/sf85p.pdf). This form includes all the questions you'll be asked so you can use it to get a head start.  
+The questionnaire you'll need to fill out is called [e-QIP](https://www.opm.gov/investigations/e-qip-application/). The questions cover seven years worth of employment and location history, among other things. It may take substantial time to collect contact information for previous employers, as well as old addresses. The e-QIP questionnaire is basically a web version of the [SF-85p](https://www.opm.gov/forms/pdf_fill/sf85p.pdf). This form includes all the questions you'll be asked so you can use it to get a head start.
 
 


### PR DESCRIPTION
The IRS Jobs link is a 404 now. I couldn't find an updated link upon some basic googling, so I removed it and reworded the sentence.
