### PR TITLE
Adds new Twitter and OpenGraph metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,18 @@ GEM
   remote: https://rubygems.org/
   specs:
     colorator (0.1)
-    ffi (1.9.10)
-    go_script (0.1.5)
+    ffi (1.9.14)
+    go_script (0.1.9)
       bundler (~> 1.10)
       safe_yaml (~> 1.0)
-    guides_style_18f (0.1.9)
+    guides_style_18f (0.4.9)
       jekyll
+      jekyll_pages_api
+      jekyll_pages_api_search
       rouge
       sass
-    jekyll (3.0.1)
+    htmlentities (4.3.4)
+    jekyll (3.1.6)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -19,25 +22,31 @@ GEM
       mercenary (~> 0.3.3)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-redirect-from (0.9.0)
+    jekyll-redirect-from (0.11.0)
       jekyll (>= 2.0)
-    jekyll-sass-converter (1.3.0)
-      sass (~> 3.2)
-    jekyll-watch (1.3.0)
-      listen (~> 3.0)
-    kramdown (1.9.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.4.0)
+      listen (~> 3.0, < 3.1)
+    jekyll_pages_api (0.1.6)
+      htmlentities (~> 4.3)
+      jekyll (>= 2.0, < 4.0)
+    jekyll_pages_api_search (0.4.4)
+      jekyll_pages_api (~> 0.1.4)
+      sass (~> 3.4)
+    kramdown (1.11.1)
     liquid (3.0.6)
-    listen (3.0.5)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    mercenary (0.3.5)
-    rb-fsevent (0.9.6)
-    rb-inotify (0.9.5)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    redcarpet (3.3.3)
-    rouge (1.10.1)
+    redcarpet (3.3.4)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.20)
+    sass (3.4.22)
 
 PLATFORMS
   ruby
@@ -50,4 +59,4 @@ DEPENDENCIES
   redcarpet
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,9 @@
+# Site metadata.
+title: Joining 18F
+url: https://pages.18f.gov/joining-18f
+description: Information on open positions at 18F, and how to join.
+
+
 markdown: redcarpet
 name: Joining 18F
 exclude:

--- a/_positions/application-security-engineer.md
+++ b/_positions/application-security-engineer.md
@@ -3,6 +3,7 @@ title: Application Security Engineer
 permalink: infosec/application-security-engineer/
 team: 18F
 active: true
+description: "18F is hiring an Application Security Engineer to help re-define how the government builds secure software. This role is perfect for you if you care deeply about shipping secure code. You should be excited to spread that knowledge throughout 18F's engineering disciplines — and beyond."
 ---
 
 18F is looking for talented security engineers to join our team and help us build secure applications. This is a unique opportunity to help re-define how the government builds secure software. You’ll be a key contributor in helping to secure the tools and technology that the American people use to interact with the government. [18F is an open source team](https://18f.gsa.gov/2014/07/29/18f-an-open-source-team/), so most of what you work on will be open source.

--- a/_positions/penetration-tester.md
+++ b/_positions/penetration-tester.md
@@ -3,6 +3,7 @@ title: Penetration Tester
 permalink: infosec/penetration-tester/
 team: 18F
 active: true
+description: "18F is hiring a Penetration Tester to help re-define how the government builds secure software. This role is perfect for you if you love 'breaking' systems to make them better. You should be excited to get to find exploits in our software — and then work with us to fix them!"
 ---
 
 18F is looking for talented security engineers to join our team and help us build secure applications. This is a unique opportunity to help re-define how the government builds secure software. You’ll be a key contributor in helping to secure the tools and technology that the American people use to interact with the government. [18F is an open source team](https://18f.gsa.gov/2014/07/29/18f-an-open-source-team/), so most of what you work on will be open source.

--- a/_positions/security-operations-engineer.md
+++ b/_positions/security-operations-engineer.md
@@ -3,6 +3,7 @@ title: Security Operations Engineer
 permalink: infosec/security-operations-engineer/
 team: 18F
 active: true
+description: "18F is looking for a Security Operations Engineer to help re-define how the government builds secure software. This role is perfect for you if you love building and improving infrastructure systemically. You should be excited to build automated systems that address security issues before they happen."
 ---
 
 18F is looking for talented security engineers to join our team and help us build secure applications. This is a unique opportunity to help re-define how the government builds secure software. You’ll be a key contributor in helping to secure the tools and technology that the American people use to interact with the government. [18F is an open source team](https://18f.gsa.gov/2014/07/29/18f-an-open-source-team/), so most of what you work on will be open source.

--- a/pages/open-positions.md
+++ b/pages/open-positions.md
@@ -2,6 +2,7 @@
 title: Open positions
 permalink: /open-positions/
 redirect_from: /roles-and-teams/
+description: "Open positions at 18F."
 ---
 
 We're briefly pausing applications while we evolve how 18F plans for open roles.


### PR DESCRIPTION
Uses the behavior introduced in https://github.com/18F/guides-style/pull/71 to add opengraph/Twitter metadata support to the Joining 18F site, and its individual positions. This will improve the share-ability of links to positions, and to the site itself.

It will not take effect until the Pages gem is updated, and the server updated. I don't know how to facilitate that process, but I believe @afeld does.
