### PR TITLE
Update application link to reflect page name

### DIFF
--- a/_includes/apply-link.md
+++ b/_includes/apply-link.md
@@ -1,1 +1,1 @@
-## [Review open positions and apply to join 18F]({{ site.baseurl }}/roles-and-teams/) 
+## [Review open positions and apply to join 18F]({{ site.baseurl }}/open-positions/)


### PR DESCRIPTION
Evidently when the relevant page changed from `roles-and-teams` to `open-positions`, the application link didn't change along with it. This PR fixes that.

Fixes https://github.com/18F/joining-18f/issues/297. (Thanks, @awfrancisco!)
