### PR TITLE
Removed incorrect statement about Unpaid Leave

### DIFF
--- a/pages/leave-policies.md
+++ b/pages/leave-policies.md
@@ -16,7 +16,6 @@ Sick leave accrues at four hours per pay period for all federal employees, regar
 ### Unpaid leave
 
 Employees can request unpaid leave of less than four weeks at any time.
-Unlike parental leave, below, you do not have to have been employed for 12 months.
 
 ### Parental leave 
 


### PR DESCRIPTION
The Unpaid Leave section said that Parental Leave could only be taken if you've been employed by 18F for 12 months.  This is an incorrect statement.  You have to be a Federal employee for 12 months to qualify for _FMLA_ leave, which is not the same as parental leave.  FMLA leave is the preferred type of parental leave, but not the only leave option available to new parents.