### PR TITLE
Changed language around posting period

### DIFF
--- a/pages/interview-process.md
+++ b/pages/interview-process.md
@@ -4,7 +4,7 @@ title: Interview process
 ---
 
 ## Application collection
-Applications are collected and grouped in two-week intervals. All applications collected within each two-week period are treated as a cohort and evaluated against each other.
+Applications are collected during the period specified by the job posting, usually 5 days to two weeks. All applications collected within this period are treated as a cohort and evaluated against each other.
 
 **Note:** Once an application period ends, no additions or modifications can be made to your application. However, there is no limit to the number of times you can apply.
 


### PR DESCRIPTION
Updated to reflect that not all jobs are posted for 2 weeks now.  We are varying the posting period based on anticipated demand, with a minimum posting period of 5 days.