### PR TITLE
Update readme to deprecate the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# :warning:DEPRECATED:warning:
+### The contents of this repo have been moved to https://github.com/18F/18f.gsa.gov.
+
+### https://pages.18f.gov/joining-18f/ is now being redirected to https://18f.gsa.gov/join/.
+
+---
+
 ## Joining 18F
 
 This is the repository for the guide to [Joining 18F](https://pages.18f.gov/joining-18f/), built on the [18F Guides Template](https://github.com/18F/guides-template).


### PR DESCRIPTION
Once [this PR](https://github.com/18F/federalist-redirects/pull/3) is merged, this repo and its corresponding URL will no longer be supported. I have updated the README to reflect that change.

I don't have collaborator status on this repo, but I would also propose that the title text be flagged as `DEPRECATED`.

cc @wslack @fureigh